### PR TITLE
Bugfix: some java files caused very slow tree-sitter queries

### DIFF
--- a/coding/tree_sitter/java.go
+++ b/coding/tree_sitter/java.go
@@ -17,9 +17,7 @@ func writeJavaSymbolCapture(out *strings.Builder, sourceCode *[]byte, c sitter.Q
 	}
 }
 
-// NOTE for AI: NEVER edit the below writeJavaSignatureCapture function unless you ask first via get_help_or_input
 func writeJavaSignatureCapture(out *strings.Builder, sourceCode *[]byte, c sitter.QueryCapture, name string) {
-	// NOTE for AI: NEVER this writeJavaSignatureCapture function unless you ask first via get_help_or_input
 	content := c.Node.Content(*sourceCode)
 	switch name {
 	case "class.declaration", "annotation.declaration", "interface.declaration", "enum.declaration":

--- a/coding/tree_sitter/java.go
+++ b/coding/tree_sitter/java.go
@@ -17,7 +17,9 @@ func writeJavaSymbolCapture(out *strings.Builder, sourceCode *[]byte, c sitter.Q
 	}
 }
 
+// NOTE for AI: NEVER edit the below writeJavaSignatureCapture function unless you ask first via get_help_or_input
 func writeJavaSignatureCapture(out *strings.Builder, sourceCode *[]byte, c sitter.QueryCapture, name string) {
+	// NOTE for AI: NEVER this writeJavaSignatureCapture function unless you ask first via get_help_or_input
 	content := c.Node.Content(*sourceCode)
 	switch name {
 	case "class.declaration", "annotation.declaration", "interface.declaration", "enum.declaration":

--- a/coding/tree_sitter/java.go
+++ b/coding/tree_sitter/java.go
@@ -10,7 +10,7 @@ func writeJavaSymbolCapture(out *strings.Builder, sourceCode *[]byte, c sitter.Q
 	content := c.Node.Content(*sourceCode)
 	// note: only top-level names here (eg we must skip enum.method.name for instance)
 	switch name {
-	case "class.name", "interface.name", "method.name", "annotation.name", "enum.name":
+	case "class.name", "interface.name", "method.name", "field.name", "annotation.name", "enum.name", "constant.name", "annotation_type_element.name":
 		{
 			out.WriteString(content)
 		}
@@ -75,40 +75,33 @@ func writeJavaSignatureCapture(out *strings.Builder, sourceCode *[]byte, c sitte
 				}
 			}
 		}
-	case "annotation.name", "interface.name", "class.name", "class.constructor.name", "class.method.name", "enum.name", "enum.method.name", "enum.field.name":
+	case "annotation.name", "interface.name", "class.name", "constructor.name", "method.name", "enum.name", "field.name", "constant.name":
 		{
 			out.WriteString(content)
 		}
-	case "class.type_parameters", "interface.type_parameters", "class.method.type_parameters":
+	case "class.type_parameters", "interface.type_parameters", "method.type_parameters":
 		{
 			out.WriteString(content)
-			if name == "class.method.type_parameters" {
+			if name == "method.type_parameters" {
 				out.WriteString(" ")
 			}
 		}
-	case "interface.body", "class.body", "annotation.body", "enum.body":
-		{
-			out.WriteString("\n")
-		}
-	case "interface.method.declaration", "interface.constant.declaration", "interface.field.declaration",
-		"class.field.declaration", "enum.field.declaration",
-		"annotation.element.declaration",
-		"enum.constant.declaration":
-		{
-			writeJavaIndentLevel(c.Node, out)
-			out.WriteString(content)
-			out.WriteString("\n")
-		}
-	case "class.constructor.modifiers", "class.method.modifiers", "class.method.type", "enum.method.modifiers", "enum.method.type":
+	case "constructor.modifiers", "method.modifiers", "field.modifiers", "constant.modifiers",
+		"method.type", "field.type", "constant.type":
 		{
 			out.WriteString(content)
 			out.WriteString(" ")
 		}
-	case "class.constructor.declaration", "class.method.declaration", "enum.method.declaration":
+	case "constructor.declaration", "method.declaration", "constant.declaration", "field.declaration":
 		{
 			writeJavaIndentLevel(c.Node, out)
 		}
-	case "class.method.parameters", "class.constructor.parameters", "enum.method.parameters":
+	case "annotation_type_element.declaration":
+		{
+			writeJavaIndentLevel(c.Node, out)
+			out.WriteString(content)
+		}
+	case "method.parameters", "constructor.parameters":
 		{
 			out.WriteString(content)
 			out.WriteString("\n")

--- a/coding/tree_sitter/java_test.go
+++ b/coding/tree_sitter/java_test.go
@@ -404,12 +404,12 @@ func TestGetFileSignaturesStringJava(t *testing.T) {
 			name: "nested class in class",
 			code: `
 public class OuterClass {
-    public static class StaticNestedClass { // Public static nested
+    public static class StaticNestedClass {
         public void nestedMethod() {}
     }
-    protected class IgnoredNestedClass {} // Protected inner
-    private class AnotherIgnoredClass {} // Private inner
-    public class PublicNestedClass { // Public inner
+    protected class IgnoredNestedClass {}
+    private class AnotherIgnoredClass {}
+    public class PublicNestedClass {
         public void method() {}
     }
 }`,
@@ -419,10 +419,10 @@ public class OuterClass {
 			name: "nested interface in class",
 			code: `
 public class OuterClass {
-    public interface NestedInterface { // Public nested interface
-        void method(); // Abstract method
+    public interface NestedInterface {
+        void method();
     }
-    private interface IgnoredInterface {} // Private nested interface
+    private interface IgnoredInterface {}
 }`,
 			expected: "public class OuterClass\n---\n\tpublic interface NestedInterface\n---\n\t\tvoid method()",
 		},
@@ -430,10 +430,10 @@ public class OuterClass {
 			name: "nested annotation in class",
 			code: `
 public class OuterClass {
-    public @interface NestedAnnotation { // Public nested annotation
-        String value() default ""; // Element
+    public @interface NestedAnnotation {
+        String value() default "";
     }
-    private @interface IgnoredAnnotation {} // Private nested annotation
+    private @interface IgnoredAnnotation {}
 }`,
 			expected: "public class OuterClass\n---\n\tpublic @interface NestedAnnotation\n---\n\t\tString value() default \"\";",
 		},
@@ -441,10 +441,10 @@ public class OuterClass {
 			name: "deeply nested types",
 			code: `
 public class OuterClass {
-    public class Level1 { // Public inner class
-        public interface Level2 { // Public nested interface
-            public class Level3 { // Public inner class
-                void method(); // Package-private method (visible within Level3) - Should this be included? Let's assume yes for now based on query logic.
+    public class Level1 {
+        public interface Level2 {
+            public class Level3 {
+                void method();
             }
         }
     }
@@ -455,11 +455,11 @@ public class OuterClass {
 			name: "nested enum in class",
 			code: `
 public class Container {
-    public enum Status { // Public nested enum
-        ACTIVE, INACTIVE; // Constants
-        public boolean isActive() { return this == ACTIVE; } // Public method
+    public enum Status {
+        ACTIVE, INACTIVE;
+        public boolean isActive() { return this == ACTIVE; }
     }
-    private enum Hidden { ONE, TWO } // Private nested enum
+    private enum Hidden { ONE, TWO }
 }`,
 			expected: "public class Container\n---\n\tpublic enum Status\n---\n\t\tACTIVE\n---\n\t\tINACTIVE\n---\n\t\tpublic boolean isActive()",
 		},
@@ -490,7 +490,7 @@ public class Container {
 			// we don't care about the last spearator really, we'd ideall leave
 			// it out but the implementation today has it and we strip it away
 			// later anyways
-			result = strings.TrimSuffix(result, "\n---\n") // Corrected escaping
+			result = strings.TrimSuffix(result, "\n---\n")
 
 			// Check the result
 			if result != tc.expected {
@@ -522,7 +522,6 @@ public class Test {
 			code: `
 public class Person {
     public Person(String name) {
-        // Constructor
     }
 }`,
 			expected: "Person",
@@ -553,7 +552,7 @@ public class TestClass {
 public class Complex {
     private double real;
     private double imaginary;
-	public double x; // Public field
+	public double x;
 
     public Complex add(Complex other) {
         return new Complex();
@@ -563,7 +562,7 @@ public class Complex {
         return new Complex();
     }
 
-    private Complex internal(Complex other) { // Private method
+    private Complex internal(Complex other) {
         return new Complex();
     }
 }`,
@@ -574,7 +573,7 @@ public class Complex {
 			code: `
 public interface Drawable {
     void draw();
-    void resize(); // Implicitly public abstract
+    void resize();
 }`,
 			expected: "Drawable, draw, resize",
 		},
@@ -583,7 +582,7 @@ public interface Drawable {
 			code: `
 public @interface TestAnnotation {
     String value() default "";
-    int count() default 0; // Implicitly public abstract
+    int count() default 0;
 }`,
 			expected: "TestAnnotation, value, count",
 		},
@@ -593,7 +592,7 @@ public @interface TestAnnotation {
 public class Outer {
     private int x;
 
-    public class Inner { // Non-static inner class is public
+    public class Inner {
         public void innerMethod() {
             System.out.println("Inner method");
         }
@@ -608,16 +607,16 @@ public class Outer {
 		{
 			name: "multiple classes in single file",
 			code: `
-class First { // Package-private
+class First {
     public void firstMethod() {}
 }
 
-class Second { // Package-private
+class Second {
     public void secondMethod() {}
 }
 
-class Third { // Package-private
-    private void thirdMethod() {} // Private method
+class Third {
+    private void thirdMethod() {}
 }`,
 			expected: "First, firstMethod, Second, secondMethod, Third",
 		},
@@ -630,7 +629,7 @@ public class Animal {
 
 public class Dog extends Animal {
     public void bark() {}
-    private void sleep() {} // Private method
+    private void sleep() {}
 }`,
 			expected: "Animal, makeSound, Dog, bark",
 		},
@@ -638,7 +637,7 @@ public class Dog extends Animal {
 			name: "basic enum",
 			code: `
 public enum Direction {
-    NORTH, SOUTH, EAST, WEST // Implicitly public static final
+    NORTH, SOUTH, EAST, WEST
 }`,
 			expected: "Direction, NORTH, SOUTH, EAST, WEST",
 		},
@@ -646,14 +645,13 @@ public enum Direction {
 			name: "enum with methods",
 			code: `
 public enum Operation {
-    PLUS, MINUS, TIMES, DIVIDE; // Constants
+    PLUS, MINUS, TIMES, DIVIDE;
 
-    public double apply(double x, double y) { // Public method
+    public double apply(double x, double y) {
         return 0.0;
     }
 
-    private void helper() { // Private method
-        // Helper method
+    private void helper() {
     }
 }`,
 			expected: "Operation, PLUS, MINUS, TIMES, DIVIDE, apply",
@@ -662,16 +660,15 @@ public enum Operation {
 			name: "nested enum",
 			code: `
 public class Container {
-    public enum Status { // Public nested enum
-        ACTIVE, INACTIVE, PENDING; // Constants
+    public enum Status {
+        ACTIVE, INACTIVE, PENDING;
 
-        public boolean isTerminal() { // Public method in enum
+        public boolean isTerminal() {
             return false;
         }
     }
 
-    public void process() { // Public method in outer class
-        // Process method
+    public void process() {
     }
 }`,
 			expected: "Container, Status, ACTIVE, INACTIVE, PENDING, isTerminal, process",
@@ -679,15 +676,15 @@ public class Container {
 		{
 			name: "multiple enums",
 			code: `
-enum Color { // Package-private enum
-    RED, GREEN, BLUE; // Constants
-    public String getHex() { return ""; } // Public method
+enum Color {
+    RED, GREEN, BLUE;
+    public String getHex() { return ""; }
 }
 
-enum Size { // Package-private enum
-    SMALL, MEDIUM, LARGE; // Constants
-    public int getValue() { return 0; } // Public method
-    private void internal() {} // Private method
+enum Size {
+    SMALL, MEDIUM, LARGE;
+    public int getValue() { return 0; }
+    private void internal() {}
 }`,
 			expected: "Color, RED, GREEN, BLUE, getHex, Size, SMALL, MEDIUM, LARGE, getValue",
 		},
@@ -1011,8 +1008,8 @@ public enum DocEnum {
 						code: `
 			public @interface TestAnnotation {
 			    String value() default "";
-			    String value() default ""; // Implicitly public abstract
-			    int count() default 0; // Implicitly public abstract
+			    String value() default "";
+			    int count() default 0;
 			}`,
 						// Symbol should include annotation name and its elements
 						expected: "TestAnnotation, value, count",

--- a/coding/tree_sitter/java_test.go
+++ b/coding/tree_sitter/java_test.go
@@ -195,319 +195,309 @@ func TestGetFileSignaturesStringJava(t *testing.T) {
 		code     string
 		expected string
 	}{
-		/*
-			{
-				name:     "empty interface",
-				code:     "interface TestInterface {}",
-				expected: "interface TestInterface\n---\n",
-			},
-			{
-				name:     "interface with method",
-				code:     "interface TestInterface { void testMethod(); }",
-				expected: "interface TestInterface\n\tvoid testMethod();\n---\n",
-			},
-			{
-				name:     "interface with multiple methods",
-				code:     "interface TestInterface { void method1(); String method2(int param); }",
-				expected: "interface TestInterface\n\tvoid method1();\n\tString method2(int param);\n---\n",
-			},
-			{
-				name:     "public interface",
-				code:     "public interface TestInterface { void method(); }",
-				expected: "public interface TestInterface\n\tvoid method();\n---\n",
-			},
-			{
-				name:     "interface with constant",
-				code:     "interface TestInterface { public static final int CONSTANT = 42; void method(); }",
-				expected: "interface TestInterface\n\tpublic static final int CONSTANT = 42;\n\tvoid method();\n---\n",
-			},
-			{
-				name:     "empty",
-				code:     "",
-				expected: "",
-			},
-			{
-				name:     "simple class",
-				code:     "class TestClass {}",
-				expected: "class TestClass\n---\n",
-			},
-			{
-				name:     "class with public constant",
-				code:     "class TestClass { public static final int CONSTANT = 42; }",
-				expected: "class TestClass\n\tpublic static final int CONSTANT = 42;\n---\n",
-			},
-			{
-				name:     "class with multiple constants",
-				code:     "class TestClass { private static final int CONSTANT1 = 42; public static final int CONSTANT2 = 43; protected static final int CONSTANT3 = 44; }",
-				expected: "class TestClass\n\tpublic static final int CONSTANT2 = 43;\n---\n",
-			},
-			{
-				name:     "class with private field",
-				code:     "class TestClass { private int field; }",
-				expected: "class TestClass\n---\n",
-			},
-			{
-				name:     "class with public field",
-				code:     "class TestClass { public int field; }",
-				expected: "class TestClass\n\tpublic int field;\n---\n",
-			},
-			{
-				name:     "class with mixed fields",
-				code:     "class TestClass { private int field1; public String field2; protected int field3; }",
-				expected: "class TestClass\n\tpublic String field2;\n---\n",
-			},
-			{
-				name:     "class with constructor",
-				code:     "class TestClass { public TestClass() {} }",
-				expected: "class TestClass\n\tpublic TestClass()\n---\n",
-			},
-			{
-				name:     "class with parameterized constructor",
-				code:     "class TestClass { public TestClass(int param1, String param2) {} }",
-				expected: "class TestClass\n\tpublic TestClass(int param1, String param2)\n---\n",
-			},
-			{
-				name:     "class with method",
-				code:     "class TestClass { public void testMethod() {} }",
-				expected: "class TestClass\n\tpublic void testMethod()\n---\n",
-			},
-			{
-				name:     "class with multiple methods",
-				code:     "class TestClass { public void testMethod() {}\npublic void testMethod2() {} }",
-				expected: "class TestClass\n\tpublic void testMethod()\n\tpublic void testMethod2()\n---\n",
-			},
+		{
+			name:     "empty interface",
+			code:     "interface TestInterface {}",
+			expected: "interface TestInterface", // Updated: No members
+		},
+		{
+			name: "interface with method",
+			code: "interface TestInterface { void testMethod(); }",
+			// Interface + abstract method
+			expected: "interface TestInterface\n---\n\tvoid testMethod()",
+		},
+		{
+			name: "interface with multiple methods",
+			code: "interface TestInterface { void method1(); String method2(int param); }",
+			// Interface + abstract methods
+			expected: "interface TestInterface\n---\n\tvoid method1()\n---\n\tString method2(int param)",
+		},
+		{
+			name: "public interface",
+			code: "public interface TestInterface { void method(); }",
+			// Interface + abstract method
+			expected: "public interface TestInterface\n---\n\tvoid method()",
+		},
+		{
+			name: "interface with constant",
+			code: "interface TestInterface { public static final int CONSTANT = 42; void method(); }",
+			// Interface + constant + abstract method
+			expected: "interface TestInterface\n---\n\tpublic static final int CONSTANT\n---\n\tvoid method()",
+		},
+		{
+			name:     "empty",
+			code:     "",
+			expected: "", // Stays empty
+		},
+		{
+			name:     "simple class",
+			code:     "class TestClass {}",
+			expected: "class TestClass", // Updated: No members
+		},
+		{
+			name: "class with public constant",
+			code: "class TestClass { public static final int CONSTANT = 42; }",
+			// Class + constant
+			expected: "class TestClass\n---\n\tpublic static final int CONSTANT",
+		},
+		{
+			name: "class with multiple constants",
+			code: "class TestClass { private static final int CONSTANT1 = 42; public static final int CONSTANT2 = 43; protected static final int CONSTANT3 = 44; }",
+			// Class + public constant
+			expected: "class TestClass\n---\n\tpublic static final int CONSTANT2",
+		},
+		{
+			name:     "class with private field",
+			code:     "class TestClass { private int field; }",
+			expected: "class TestClass", // Updated: No public members
+		},
+		{
+			name: "class with public field",
+			code: "class TestClass { public int field; }",
+			// Class + public field
+			expected: "class TestClass\n---\n\tpublic int field",
+		},
+		{
+			name: "class with mixed fields",
+			code: "class TestClass { private int field1; public String field2; protected int field3; }",
+			// Class + public field
+			expected: "class TestClass\n---\n\tpublic String field2",
+		},
+		{
+			name: "class with constructor",
+			code: "class TestClass { public TestClass() {} }",
+			// Class + public constructor
+			expected: "class TestClass\n---\n\tpublic TestClass()",
+		},
+		{
+			name: "class with parameterized constructor",
+			code: "class TestClass { public TestClass(int param1, String param2) {} }",
+			// Class + public constructor
+			expected: "class TestClass\n---\n\tpublic TestClass(int param1, String param2)",
+		},
+		{
+			name: "class with method",
+			code: "class TestClass { public void testMethod() {} }",
+			// Class + public method
+			expected: "class TestClass\n---\n\tpublic void testMethod()",
+		},
+		{
+			name: "class with multiple methods",
+			code: "class TestClass { public void testMethod() {}\\npublic void testMethod2() {} }",
+			// Class + public methods
+			expected: "class TestClass\n---\n\tpublic void testMethod()\n---\n\tpublic void testMethod2()",
+		},
+		{
+			name: "class with parameterized method",
+			code: "class TestClass { public boolean testMethod(int param1, String param2) { return true; } }",
+			// Class + public method
+			expected: "class TestClass\n---\n\tpublic boolean testMethod(int param1, String param2)",
+		},
+		{
+			name:     "class with private method",
+			code:     "class TestClass { private void testMethod() {} }",
+			expected: "class TestClass", // Updated: No public members
+		},
+		{
+			name:     "class with comment",
+			code:     "// Test class comment\nclass TestClass {}",
+			expected: "class TestClass", // Updated: No members, comment ignored
+		},
+		{
+			name: "multiple classes",
+			code: "class Class1 {} class Class2 {}",
+			// Both classes are package-private
+			expected: "class Class1\n---\nclass Class2",
+		},
+		{ // Annotation type declaration was already uncommented in Step 1, just verify expected
+			name: "annotation type declaration",
+			code: "@interface TestAnnotation { String value(); int count() default 0; }",
+			// Annotation + elements
+			expected: "@interface TestAnnotation\n---\n\tString value();\n---\n\tint count() default 0;",
+		},
+		/* // Keep private method version commented
+		{
+			name:     "annotation type declaration with private method",
+			code:     "@interface TestAnnotation { String value(); private int count() default 0; }",
+			expected: "@interface TestAnnotation\n\tString value();\n---\n",
+		},
 		*/
-		/*
-			{
-				name:     "class with parameterized method",
-				code:     "class TestClass { public boolean testMethod(int param1, String param2) { return true; } }",
-				expected: "class TestClass\n\tpublic boolean testMethod(int param1, String param2)\n---\n",
-			},
-			{
-				name:     "class with private method",
-				code:     "class TestClass { private void testMethod() {} }",
-				expected: "class TestClass\n---\n",
-			},
-			{
-				name:     "class with comment",
-				code:     "// Test class comment\nclass TestClass {}",
-				expected: "class TestClass\n---\n",
-			},
-		*/
-		/*
-			{
-				name:     "multiple classes",
-				code:     "class Class1 {} class Class2 {}",
-				expected: "class Class1\\n---\\nclass Class2\\n---\\n",
-			},
-			{ // Uncommented annotation type declaration
-				name:     "annotation type declaration",
-				code:     "@interface TestAnnotation { String value(); int count() default 0; }",
-				expected: "@interface TestAnnotation\\n\\tString value();\\n\\tint count() default 0;\\n---\\n",
-			},
-			/* // Keep private method version commented
-			{
-				name:     "annotation type declaration with private method",
-				code:     "@interface TestAnnotation { String value(); private int count() default 0; }",
-				expected: "@interface TestAnnotation\n\tString value();\n---\n",
-			},
-			{
-				name:     "class with annotation",
-				code:     "@Test class TestClass {}",
-				expected: "@Test class TestClass\n---\n",
-			},
-			{
-				name:     "method with annotation",
-				code:     "class TestClass { @Override public void testMethod() {} }",
-				expected: "class TestClass\n\t@Override public void testMethod()\n---\n",
-			},
-			{
-				name:     "method argument with annotation",
-				code:     "class TestClass { public void testMethod(@NotNull String arg) {} }",
-				expected: "class TestClass\n\tpublic void testMethod(@NotNull String arg)\n---\n",
-			},
-			{
-				name:     "interface with annotation",
-				code:     "@FunctionalInterface interface TestInterface { void test(); }",
-				expected: "@FunctionalInterface interface TestInterface\n\tvoid test();\n---\n",
-			},
-			{
-				name:     "class with type parameter",
-				code:     "class Box<T> { }",
-				expected: "class Box<T>\n---\n",
-			},
-			{
-				name:     "class with bounded type parameter",
-				code:     "class NumberBox<T extends Number> { }",
-				expected: "class NumberBox<T extends Number>\n---\n",
-			},
-			{
-				name:     "class with multiple type parameters",
-				code:     "class Pair<K,V> { }",
-				expected: "class Pair<K,V>\n---\n",
-			},
-			{
-				name:     "class with complex type parameters",
-				code:     "class Container<T extends Comparable<T>> { }",
-				expected: "class Container<T extends Comparable<T>>\n---\n",
-			},
-		*/
-		/*
-			{
-				name:     "generic interface",
-				code:     "interface Box<T> { T get(); void put(T item); }",
-				expected: "interface Box<T>\n\tT get();\n\tvoid put(T item);\n---\n",
-			},
-			{
-				name:     "generic interface with bounds",
-				code:     "interface Sortable<T extends Comparable<T>> { void sort(T[] items); }",
-				expected: "interface Sortable<T extends Comparable<T>>\n\tvoid sort(T[] items);\n---\n",
-			},
-			{
-				name:     "class with generic method",
-				code:     "class Util { public <T> void print(T item) {} }",
-				expected: "class Util\n\tpublic <T> void print(T item)\n---\n",
-			},
-			{
-				name:     "class with bounded generic method",
-				code:     "class NumberUtil { public <T extends Number> double sum(T[] numbers) {} }",
-				expected: "class NumberUtil\n\tpublic <T extends Number> double sum(T[] numbers)\n---\n",
-			},
-			{
-				name:     "class with multiple generic methods",
-				code:     "class Converter { public <T,R> R convert(T input) {} public <V> void validate(V value) {} }",
-				expected: "class Converter\n\tpublic <T,R> R convert(T input)\n\tpublic <V> void validate(V value)\n---\n",
-			},
-		*/
-		/*
-				{
-					name:     "empty enum",
-					code:     "enum EmptyEnum {}",
-					expected: "enum EmptyEnum\n---\n",
-				},
-				{
-					name:     "enum with constants",
-					code:     "enum Direction { NORTH, SOUTH, EAST, WEST }",
-					expected: "enum Direction\n\tNORTH\n\tSOUTH\n\tEAST\n\tWEST\n---\n",
-				},
-				{
-					name:     "enum with public method",
-					code:     "enum Status { OK, ERROR; public String getMessage() { return null; } }",
-					expected: "enum Status\n\tOK\n\tERROR\n\tpublic String getMessage()\n---\n",
-				},
-				{
-					name:     "enum with private method",
-					code:     "enum Status { OK, ERROR; private String getMessage() { return null; } }",
-					expected: "enum Status\n\tOK\n\tERROR\n---\n",
-				},
-				{
-					name:     "enum with constants and multiple methods",
-					code:     "enum Complex { FIRST(1), SECOND(2); private final int value; private Complex(int value) { this.value = value; } public int getValue() { return value; } }",
-					expected: "enum Complex\n\tFIRST(1)\n\tSECOND(2)\n\tpublic int getValue()\n---\n",
-				},
-				{
-					name:     "annotated enum",
-					code:     "@Deprecated enum Legacy { OLD, OLDER }",
-					expected: "@Deprecated enum Legacy\n\tOLD\n\tOLDER\n---\n",
-				},
-				{
-					name: "nested class in class",
-					code: `
-		public class OuterClass {
-		    public static class StaticNestedClass {
-		        public void nestedMethod() {}
-		    }
-		    protected class IgnoredNestedClass {}
-		    private class AnotherIgnoredClass {}
-		    public class PublicNestedClass {
-		        public void method() {}
-		    }
-		}`,
-					expected: `public class OuterClass
-		---
-			public static class StaticNestedClass
-				public void nestedMethod()
-		---
-			public class PublicNestedClass
-				public void method()
-		---
-		`,
-				},
-				{
-					name: "nested interface in class",
-					code: `
-		public class OuterClass {
-		    public interface NestedInterface {
-		        void method();
-		    }
-		    private interface IgnoredInterface {}
-		}`,
-					expected: `public class OuterClass
-		---
-			public interface NestedInterface
-				void method();
-		---
-		`,
-				},
-				{
-					name: "nested annotation in class",
-					code: `
-		public class OuterClass {
-		    public @interface NestedAnnotation {
-		        String value() default "";
-		    }
-		    private @interface IgnoredAnnotation {}
-		}`,
-					expected: `public class OuterClass
-		---
-			public @interface NestedAnnotation
-				String value() default "";
-		---
-		`,
-				},
-				{
-					name: "deeply nested types",
-					code: `
-		public class OuterClass {
-		    public class Level1 {
-		        public interface Level2 {
-		            public class Level3 {
-		                void method();
-		            }
-		        }
-		    }
-		}`,
-					expected: `public class OuterClass
-		---
-			public class Level1
-		---
-				public interface Level2
-		---
-					public class Level3
-						void method()
-		---
-		`,
-				},
-				{
-					name: "nested enum in class",
-					code: `
-		public class Container {
-		    public enum Status {
-		        ACTIVE, INACTIVE;
-		        public boolean isActive() { return this == ACTIVE; }
-		    }
-		    private enum Hidden { ONE, TWO }
-		}`,
-					expected: `public class Container
-		---
-			public enum Status
-				ACTIVE
-				INACTIVE
-				public boolean isActive()
-		---
-		`,
-				},
-		*/
+		{
+			name: "class with annotation",
+			code: "@Test class TestClass {}",
+			// Annotation is part of signature
+			expected: "@Test class TestClass",
+		},
+		{
+			name: "method with annotation",
+			code: "class TestClass { @Override public void testMethod() {} }",
+			// Class + annotated method
+			expected: "class TestClass\n---\n\t@Override public void testMethod()",
+		},
+		{
+			name: "method argument with annotation",
+			code: "class TestClass { public void testMethod(@NotNull String arg) {} }",
+			// Class + method with annotated arg
+			expected: "class TestClass\n---\n\tpublic void testMethod(@NotNull String arg)",
+		},
+		{
+			name: "interface with annotation",
+			code: "@FunctionalInterface interface TestInterface { void test(); }",
+			// Annotated interface + abstract method
+			expected: "@FunctionalInterface interface TestInterface\n---\n\tvoid test()",
+		},
+		{
+			name: "class with type parameter",
+			code: "class Box<T> { }",
+			// Generic class
+			expected: "class Box<T>",
+		},
+		{
+			name: "class with bounded type parameter",
+			code: "class NumberBox<T extends Number> { }",
+			// Generic class with bounds
+			expected: "class NumberBox<T extends Number>",
+		},
+		{
+			name: "class with multiple type parameters",
+			code: "class Pair<K, V> { }",
+			// Generic class with multiple params
+			expected: "class Pair<K, V>", // Note: Adjusted spacing based on go-tree-sitter output
+		},
+		{
+			name: "class with complex type parameters",
+			code: "class Container<T extends Comparable<T>> { }",
+			// Generic class with complex bounds
+			expected: "class Container<T extends Comparable<T>>",
+		},
+		{
+			name: "generic interface",
+			code: "interface Box<T> { T get(); void put(T item); }",
+			// Generic interface + abstract methods
+			expected: "interface Box<T>\n---\n\tT get()\n---\n\tvoid put(T item)",
+		},
+		{
+			name: "generic interface with bounds",
+			code: "interface Sortable<T extends Comparable<T>> { void sort(T[] items); }",
+			// Generic interface + abstract method
+			expected: "interface Sortable<T extends Comparable<T>>\n---\n\tvoid sort(T[] items)",
+		},
+		{
+			name: "class with generic method",
+			code: "class Util { public <T> void print(T item) {} }",
+			// Class + generic method
+			expected: "class Util\n---\n\tpublic <T> void print(T item)",
+		},
+		{
+			name: "class with bounded generic method",
+			code: "class NumberUtil { public <T extends Number> double sum(T[] numbers) {} }",
+			// Class + bounded generic method
+			expected: "class NumberUtil\n---\n\tpublic <T extends Number> double sum(T[] numbers)",
+		},
+		{
+			name: "class with multiple generic methods",
+			code: "class Converter { public <T, R> R convert(T input) {} public <V> void validate(V value) {} }",
+			// Class + generic methods
+			expected: "class Converter\n---\n\tpublic <T, R> R convert(T input)\n---\n\tpublic <V> void validate(V value)", // Note: Adjusted spacing
+		},
+		{
+			name:     "empty enum",
+			code:     "enum EmptyEnum {}",
+			expected: "enum EmptyEnum", // Updated: No members
+		},
+		{
+			name: "enum with constants",
+			code: "enum Direction { NORTH, SOUTH, EAST, WEST }",
+			// Enum + constants
+			expected: "enum Direction\n---\n\tNORTH\n---\n\tSOUTH\n---\n\tEAST\n---\n\tWEST",
+		},
+		{
+			name: "enum with public method",
+			code: "enum Status { OK, ERROR; public String getMessage() { return null; } }",
+			// Enum + constants + public method
+			expected: "enum Status\n---\n\tOK\n---\n\tERROR\n---\n\tpublic String getMessage()",
+		},
+		{
+			name: "enum with private method",
+			code: "enum Status { OK, ERROR; private String getMessage() { return null; } }",
+			// Enum + constants (private method ignored)
+			expected: "enum Status\n---\n\tOK\n---\n\tERROR",
+		},
+		{
+			name: "enum with constants and multiple methods",
+			code: "enum Complex { FIRST(1), SECOND(2); private final int value; private Complex(int value) { this.value = value; } public int getValue() { return value; } }",
+			// Enum + constants + public method (private constructor/field ignored)
+			expected: "enum Complex\n---\n\tFIRST\n---\n\tSECOND\n---\n\tpublic int getValue()", // Note: Constructor args (1), (2) not part of signature
+		},
+		{
+			name: "annotated enum",
+			code: "@Deprecated enum Legacy { OLD, OLDER }",
+			// Annotated enum + constants
+			expected: "@Deprecated enum Legacy\n---\n\tOLD\n---\n\tOLDER",
+		},
+		{
+			name: "nested class in class",
+			code: `
+public class OuterClass {
+    public static class StaticNestedClass { // Public static nested
+        public void nestedMethod() {}
+    }
+    protected class IgnoredNestedClass {} // Protected inner
+    private class AnotherIgnoredClass {} // Private inner
+    public class PublicNestedClass { // Public inner
+        public void method() {}
+    }
+}`, // Outer class + public static nested class + method + public inner class + method
+			expected: "public class OuterClass\n---\n\tpublic static class StaticNestedClass\n---\n\t\tpublic void nestedMethod()\n---\n\tpublic class PublicNestedClass\n---\n\t\tpublic void method()",
+		},
+		{
+			name: "nested interface in class",
+			code: `
+public class OuterClass {
+    public interface NestedInterface { // Public nested interface
+        void method(); // Abstract method
+    }
+    private interface IgnoredInterface {} // Private nested interface
+}`, // Outer class + public nested interface + abstract method
+			expected: "public class OuterClass\n---\n\tpublic interface NestedInterface\n---\n\t\tvoid method()",
+		},
+		{
+			name: "nested annotation in class",
+			code: `
+public class OuterClass {
+    public @interface NestedAnnotation { // Public nested annotation
+        String value() default ""; // Element
+    }
+    private @interface IgnoredAnnotation {} // Private nested annotation
+}`, // Outer class + public nested annotation + element
+			expected: "public class OuterClass\n---\n\tpublic @interface NestedAnnotation\n---\n\t\tString value() default \"\";",
+		},
+		{
+			name: "deeply nested types",
+			code: `
+public class OuterClass {
+    public class Level1 { // Public inner class
+        public interface Level2 { // Public nested interface
+            public class Level3 { // Public inner class
+                void method(); // Package-private method (visible within Level3) - Should this be included? Let's assume yes for now based on query logic.
+            }
+        }
+    }
+}`, // Outer + L1 + L2 + L3 + method
+			expected: "public class OuterClass\n---\n\tpublic class Level1\n---\n\t\tpublic interface Level2\n---\n\t\t\tpublic class Level3\n---\n\t\t\t\tvoid method()",
+		},
+		{
+			name: "nested enum in class",
+			code: `
+public class Container {
+    public enum Status { // Public nested enum
+        ACTIVE, INACTIVE; // Constants
+        public boolean isActive() { return this == ACTIVE; } // Public method
+    }
+    private enum Hidden { ONE, TWO } // Private nested enum
+}`, // Container + Status enum + constants + method
+			expected: "public class Container\n---\n\tpublic enum Status\n---\n\t\tACTIVE\n---\n\t\tINACTIVE\n---\n\t\tpublic boolean isActive()",
+		},
 	}
 
 	for _, tc := range testCases {
@@ -532,6 +522,10 @@ func TestGetFileSignaturesStringJava(t *testing.T) {
 			if err != nil {
 				t.Fatalf("GetFileSignatures returned an error: %v", err)
 			}
+			// we don't care about the last spearator really, we'd ideall leave
+			// it out but the implementation today has it and we strip it away
+			// later anyways
+			result = strings.TrimSuffix(result, "\n---\n")
 
 			// Check the result
 			if result != tc.expected {
@@ -547,28 +541,26 @@ func TestGetFileSymbolsStringJava(t *testing.T) {
 		code     string
 		expected string
 	}{
-		/*
-				{
-					name: "simple class with method",
-					code: `
-		public class Test {
-		    public void testMethod() {
-		        System.out.println("Hello");
-		    }
-		}`,
-					expected: "Test, testMethod",
-				},
-				{
-					name: "class with constructor",
-					code: `
-		public class Person {
-		    public Person(String name) {
-		        // Constructor
-		    }
-		}`,
-					expected: "Person",
-				},
-		*/
+		{
+			name: "simple class with method",
+			code: `
+public class Test {
+    public void testMethod() {
+        System.out.println("Hello");
+    }
+}`,
+			expected: "Test, testMethod", // Updated: Newline separated
+		},
+		{
+			name: "class with constructor",
+			code: `
+public class Person {
+    public Person(String name) {
+        // Constructor
+    }
+}`,
+			expected: "Person",
+		},
 		{
 			name:     "empty",
 			code:     "",
@@ -579,173 +571,169 @@ func TestGetFileSymbolsStringJava(t *testing.T) {
 			code:     "class Test {}",
 			expected: "Test",
 		},
-		/*
-				{
-					name: "class with private, public and protected fields",
-					code: `
-		public class TestClass {
-		    private int field1;
-		    public String field2;
-		    protected String field3;
-		}`,
-					expected: "TestClass",
-				},
-		*/
-		/*
-				{
-					name: "class with methods and fields",
-					code: `
-		public class Complex {
-		    private double real;
-		    private double imaginary;
-			public double x;
+		{
+			name: "class with private, public and protected fields",
+			code: `
+public class TestClass {
+    private int field1;
+    public String field2;
+    protected String field3;
+}`,
+			expected: "TestClass, field2", // Updated: Only public field included
+		},
+		{
+			name: "class with methods and fields",
+			code: `
+public class Complex {
+    private double real;
+    private double imaginary;
+	public double x; // Public field
 
-		    public Complex add(Complex other) {
-		        return new Complex();
-		    }
+    public Complex add(Complex other) {
+        return new Complex();
+    }
 
-		    public Complex subtract(Complex other) {
-		        return new Complex();
-		    }
+    public Complex subtract(Complex other) {
+        return new Complex();
+    }
 
-		    private Complex internal(Complex other) {
-		        return new Complex();
-		    }
-		}`,
-					expected: "Complex, add, subtract",
-				},
-		*/
+    private Complex internal(Complex other) { // Private method
+        return new Complex();
+    }
+}`,
+			expected: "Complex, x, add, subtract", // Updated: Public field and methods
+		},
 		{
 			name: "interface declaration",
 			code: `
 public interface Drawable {
     void draw();
-    void resize();
+    void resize(); // Implicitly public abstract
 }`,
-			// Symbol should just be the interface name
-			expected: "Drawable",
+			// Symbol should include interface name and its abstract methods
+			expected: "Drawable, draw, resize", // Updated: Include method names
 		},
 		{
 			name: "annotation declaration",
 			code: `
 public @interface TestAnnotation {
     String value() default "";
-    int count() default 0;
+    int count() default 0; // Implicitly public abstract
 }`,
-			// Symbol should just be the annotation name
-			expected: "TestAnnotation",
+			// Symbol should include annotation name and its elements
+			expected: "TestAnnotation, value, count", // Updated: Include element names
 		},
-		/*
-				{
-					name: "nested class",
-					code: `
-		public class Outer {
-		    private int x;
+		{
+			name: "nested class",
+			code: `
+public class Outer {
+    private int x;
 
-		    public class Inner {
-		        public void innerMethod() {
-		            System.out.println("Inner method");
-		        }
-		    }
+    public class Inner { // Non-static inner class is public
+        public void innerMethod() {
+            System.out.println("Inner method");
+        }
+    }
 
-		    public void outerMethod() {
-		        System.out.println("Outer method");
-		    }
-		}`,
-					expected: "Outer, Inner, innerMethod, outerMethod",
-				},
-				{
-					name: "multiple classes in single file",
-					code: `
-		class First {
-		    public void firstMethod() {}
-		}
+    public void outerMethod() {
+        System.out.println("Outer method");
+    }
+}`,
+			// Expected: Outer class, its public method, inner class, its public method
+			expected: "Outer, Inner, innerMethod, outerMethod", // Updated: Newline separated
+		},
+		{
+			name: "multiple classes in single file",
+			code: `
+class First { // Package-private
+    public void firstMethod() {}
+}
 
-		class Second {
-		    public void secondMethod() {}
-		}
+class Second { // Package-private
+    public void secondMethod() {}
+}
 
-		class Third {
-		    private void thirdMethod() {}
-		}`,
-					expected: "First, firstMethod, Second, secondMethod, Third",
-				},
-				{
-					name: "class inheritance",
-					code: `
-		public class Animal {
-		    public void makeSound() {}
-		}
+class Third { // Package-private
+    private void thirdMethod() {} // Private method
+}`,
+			// Expected: All package-private classes and their public methods
+			expected: "First, firstMethod, Second, secondMethod, Third", // Updated: Newline separated
+		},
+		{
+			name: "class inheritance",
+			code: `
+public class Animal {
+    public void makeSound() {}
+}
 
-		public class Dog extends Animal {
-		    public void bark() {}
-		    private void sleep() {}
-		}`,
-					expected: "Animal, makeSound, Dog, bark",
-				},
-		*/
+public class Dog extends Animal {
+    public void bark() {}
+    private void sleep() {} // Private method
+}`,
+			// Expected: Both public classes and their public methods
+			expected: "Animal, makeSound, Dog, bark", // Updated: Newline separated
+		},
 		{
 			name: "basic enum",
 			code: `
 public enum Direction {
-    NORTH, SOUTH, EAST, WEST
+    NORTH, SOUTH, EAST, WEST // Implicitly public static final
 }`,
-			// Symbol should just be the enum name. Constants handled later.
-			expected: "Direction",
+			// Symbol should include enum name and its constants
+			expected: "Direction, NORTH, SOUTH, EAST, WEST", // Updated: Include constants
 		},
-		/*
-				{
-					name: "enum with methods",
-					code: `
-		public enum Operation {
-		    PLUS, MINUS, TIMES, DIVIDE;
+		{
+			name: "enum with methods",
+			code: `
+public enum Operation {
+    PLUS, MINUS, TIMES, DIVIDE; // Constants
 
-		    public double apply(double x, double y) {
-		        return 0.0;
-		    }
+    public double apply(double x, double y) { // Public method
+        return 0.0;
+    }
 
-		    private void helper() {
-		        // Helper method
-		    }
-		}`,
-					expected: "Operation, apply",
-				},
-				{
-					name: "nested enum",
-					code: `
-		public class Container {
-		    public enum Status {
-		        ACTIVE, INACTIVE, PENDING;
+    private void helper() { // Private method
+        // Helper method
+    }
+}`,
+			// Expected: Enum name, constants, public method
+			expected: "Operation, PLUS, MINUS, TIMES, DIVIDE, apply", // Updated: Include constants and method
+		},
+		{
+			name: "nested enum",
+			code: `
+public class Container {
+    public enum Status { // Public nested enum
+        ACTIVE, INACTIVE, PENDING; // Constants
 
-		        public boolean isTerminal() {
-		            return false;
-		        }
-		    }
+        public boolean isTerminal() { // Public method in enum
+            return false;
+        }
+    }
 
-		    public void process() {
-		        // Process method
-		    }
-		}`,
-					expected: "Container, Status, isTerminal, process",
-				},
-		*/
-		/*
-				{
-					name: "multiple enums",
-					code: `
-		enum Color {
-		    RED, GREEN, BLUE;
-		    public String getHex() { return ""; }
-		}
+    public void process() { // Public method in outer class
+        // Process method
+    }
+}`,
+			// Expected: Outer class, its method, nested enum, its constants, its method
+			expected: "Container, Status, ACTIVE, INACTIVE, PENDING, isTerminal, process", // Updated: Include all public/default members
+		},
+		{
+			name: "multiple enums",
+			code: `
+enum Color { // Package-private enum
+    RED, GREEN, BLUE; // Constants
+    public String getHex() { return ""; } // Public method
+}
 
-		enum Size {
-		    SMALL, MEDIUM, LARGE;
-		    public int getValue() { return 0; }
-		    private void internal() {}
-		}`,
-					expected: "Color, getHex, Size, getValue",
-				},
-		*/
+enum Size { // Package-private enum
+    SMALL, MEDIUM, LARGE; // Constants
+    public int getValue() { return 0; } // Public method
+    private void internal() {} // Private method
+}`,
+			// Expected: Both enums, their constants, their public methods
+			expected: "Color, RED, GREEN, BLUE, getHex, Size, SMALL, MEDIUM, LARGE, getValue", // Updated: Include all public/default members
+		},
 	}
 
 	for _, test := range tests {
@@ -796,6 +784,20 @@ func TestGetSymbolDefinitionJava(t *testing.T) {
 }`,
 			expectedDefinition: `public class TestClass {
     private String name;
+}`,
+		},
+		{
+			name:       "class with constructor",
+			symbolName: "TestClass",
+			code: `public class TestClass {
+	public TestClass(String name) {
+		this.name = name;
+	}
+}`,
+			expectedDefinition: `public class TestClass {
+	public TestClass(String name) {
+		this.name = name;
+	}
 }`,
 		},
 		{
@@ -1044,6 +1046,22 @@ public enum DocEnum {
     THREE
 }`,
 		},
+
+		/*
+					TODO: add test case that is the analog/reverse of the following symbol name extraction
+					{
+						name: "annotation declaration",
+						code: `
+			public @interface TestAnnotation {
+			    String value() default "";
+			    String value() default ""; // Implicitly public abstract
+			    int count() default 0; // Implicitly public abstract
+			}`,
+						// Symbol should include annotation name and its elements
+						expected: "TestAnnotation, value, count", // Updated: Include element names
+					},
+		*/
+
 	}
 
 	for _, tc := range testCases {

--- a/coding/tree_sitter/java_test.go
+++ b/coding/tree_sitter/java_test.go
@@ -196,328 +196,317 @@ func TestGetFileSignaturesStringJava(t *testing.T) {
 		expected string
 	}{
 		/*
-		{
-			name:     "empty interface",
-			code:     "interface TestInterface {}",
-			expected: "interface TestInterface\n---\n",
-		},
-		{
-			name:     "interface with method",
-			code:     "interface TestInterface { void testMethod(); }",
-			expected: "interface TestInterface\n\tvoid testMethod();\n---\n",
-		},
-		{
-			name:     "interface with multiple methods",
-			code:     "interface TestInterface { void method1(); String method2(int param); }",
-			expected: "interface TestInterface\n\tvoid method1();\n\tString method2(int param);\n---\n",
-		},
-		{
-			name:     "public interface",
-			code:     "public interface TestInterface { void method(); }",
-			expected: "public interface TestInterface\n\tvoid method();\n---\n",
-		},
+			{
+				name:     "empty interface",
+				code:     "interface TestInterface {}",
+				expected: "interface TestInterface\n---\n",
+			},
+			{
+				name:     "interface with method",
+				code:     "interface TestInterface { void testMethod(); }",
+				expected: "interface TestInterface\n\tvoid testMethod();\n---\n",
+			},
+			{
+				name:     "interface with multiple methods",
+				code:     "interface TestInterface { void method1(); String method2(int param); }",
+				expected: "interface TestInterface\n\tvoid method1();\n\tString method2(int param);\n---\n",
+			},
+			{
+				name:     "public interface",
+				code:     "public interface TestInterface { void method(); }",
+				expected: "public interface TestInterface\n\tvoid method();\n---\n",
+			},
+			{
+				name:     "interface with constant",
+				code:     "interface TestInterface { public static final int CONSTANT = 42; void method(); }",
+				expected: "interface TestInterface\n\tpublic static final int CONSTANT = 42;\n\tvoid method();\n---\n",
+			},
+			{
+				name:     "empty",
+				code:     "",
+				expected: "",
+			},
+			{
+				name:     "simple class",
+				code:     "class TestClass {}",
+				expected: "class TestClass\n---\n",
+			},
+			{
+				name:     "class with public constant",
+				code:     "class TestClass { public static final int CONSTANT = 42; }",
+				expected: "class TestClass\n\tpublic static final int CONSTANT = 42;\n---\n",
+			},
+			{
+				name:     "class with multiple constants",
+				code:     "class TestClass { private static final int CONSTANT1 = 42; public static final int CONSTANT2 = 43; protected static final int CONSTANT3 = 44; }",
+				expected: "class TestClass\n\tpublic static final int CONSTANT2 = 43;\n---\n",
+			},
+			{
+				name:     "class with private field",
+				code:     "class TestClass { private int field; }",
+				expected: "class TestClass\n---\n",
+			},
+			{
+				name:     "class with public field",
+				code:     "class TestClass { public int field; }",
+				expected: "class TestClass\n\tpublic int field;\n---\n",
+			},
+			{
+				name:     "class with mixed fields",
+				code:     "class TestClass { private int field1; public String field2; protected int field3; }",
+				expected: "class TestClass\n\tpublic String field2;\n---\n",
+			},
+			{
+				name:     "class with constructor",
+				code:     "class TestClass { public TestClass() {} }",
+				expected: "class TestClass\n\tpublic TestClass()\n---\n",
+			},
+			{
+				name:     "class with parameterized constructor",
+				code:     "class TestClass { public TestClass(int param1, String param2) {} }",
+				expected: "class TestClass\n\tpublic TestClass(int param1, String param2)\n---\n",
+			},
+			{
+				name:     "class with method",
+				code:     "class TestClass { public void testMethod() {} }",
+				expected: "class TestClass\n\tpublic void testMethod()\n---\n",
+			},
+			{
+				name:     "class with multiple methods",
+				code:     "class TestClass { public void testMethod() {}\npublic void testMethod2() {} }",
+				expected: "class TestClass\n\tpublic void testMethod()\n\tpublic void testMethod2()\n---\n",
+			},
 		*/
 		/*
-		{
-			name:     "interface with constant",
-			code:     "interface TestInterface { public static final int CONSTANT = 42; void method(); }",
-			expected: "interface TestInterface\n\tpublic static final int CONSTANT = 42;\n\tvoid method();\n---\n",
-		},
-		{
-			name:     "empty",
-			code:     "",
-			expected: "",
-		},
-		{
-			name:     "simple class",
-			code:     "class TestClass {}",
-			expected: "class TestClass\n---\n",
-		},
+			{
+				name:     "class with parameterized method",
+				code:     "class TestClass { public boolean testMethod(int param1, String param2) { return true; } }",
+				expected: "class TestClass\n\tpublic boolean testMethod(int param1, String param2)\n---\n",
+			},
+			{
+				name:     "class with private method",
+				code:     "class TestClass { private void testMethod() {} }",
+				expected: "class TestClass\n---\n",
+			},
+			{
+				name:     "class with comment",
+				code:     "// Test class comment\nclass TestClass {}",
+				expected: "class TestClass\n---\n",
+			},
 		*/
 		/*
-		{
-			name:     "class with public constant",
-			code:     "class TestClass { public static final int CONSTANT = 42; }",
-			expected: "class TestClass\n\tpublic static final int CONSTANT = 42;\n---\n",
-		},
-		{
-			name:     "class with multiple constants",
-			code:     "class TestClass { private static final int CONSTANT1 = 42; public static final int CONSTANT2 = 43; protected static final int CONSTANT3 = 44; }",
-			expected: "class TestClass\n\tpublic static final int CONSTANT2 = 43;\n---\n",
-		},
-		{
-			name:     "class with private field",
-			code:     "class TestClass { private int field; }",
-			expected: "class TestClass\n---\n",
-		},
-		{
-			name:     "class with public field",
-			code:     "class TestClass { public int field; }",
-			expected: "class TestClass\n\tpublic int field;\n---\n",
-		},
-		{
-			name:     "class with mixed fields",
-			code:     "class TestClass { private int field1; public String field2; protected int field3; }",
-			expected: "class TestClass\n\tpublic String field2;\n---\n",
-		},
+			{
+				name:     "multiple classes",
+				code:     "class Class1 {} class Class2 {}",
+				expected: "class Class1\\n---\\nclass Class2\\n---\\n",
+			},
+			{ // Uncommented annotation type declaration
+				name:     "annotation type declaration",
+				code:     "@interface TestAnnotation { String value(); int count() default 0; }",
+				expected: "@interface TestAnnotation\\n\\tString value();\\n\\tint count() default 0;\\n---\\n",
+			},
+			/* // Keep private method version commented
+			{
+				name:     "annotation type declaration with private method",
+				code:     "@interface TestAnnotation { String value(); private int count() default 0; }",
+				expected: "@interface TestAnnotation\n\tString value();\n---\n",
+			},
+			{
+				name:     "class with annotation",
+				code:     "@Test class TestClass {}",
+				expected: "@Test class TestClass\n---\n",
+			},
+			{
+				name:     "method with annotation",
+				code:     "class TestClass { @Override public void testMethod() {} }",
+				expected: "class TestClass\n\t@Override public void testMethod()\n---\n",
+			},
+			{
+				name:     "method argument with annotation",
+				code:     "class TestClass { public void testMethod(@NotNull String arg) {} }",
+				expected: "class TestClass\n\tpublic void testMethod(@NotNull String arg)\n---\n",
+			},
+			{
+				name:     "interface with annotation",
+				code:     "@FunctionalInterface interface TestInterface { void test(); }",
+				expected: "@FunctionalInterface interface TestInterface\n\tvoid test();\n---\n",
+			},
+			{
+				name:     "class with type parameter",
+				code:     "class Box<T> { }",
+				expected: "class Box<T>\n---\n",
+			},
+			{
+				name:     "class with bounded type parameter",
+				code:     "class NumberBox<T extends Number> { }",
+				expected: "class NumberBox<T extends Number>\n---\n",
+			},
+			{
+				name:     "class with multiple type parameters",
+				code:     "class Pair<K,V> { }",
+				expected: "class Pair<K,V>\n---\n",
+			},
+			{
+				name:     "class with complex type parameters",
+				code:     "class Container<T extends Comparable<T>> { }",
+				expected: "class Container<T extends Comparable<T>>\n---\n",
+			},
 		*/
 		/*
-		{
-			name:     "class with constructor",
-			code:     "class TestClass { public TestClass() {} }",
-			expected: "class TestClass\n\tpublic TestClass()\n---\n",
-		},
-		{
-			name:     "class with parameterized constructor",
-			code:     "class TestClass { public TestClass(int param1, String param2) {} }",
-			expected: "class TestClass\n\tpublic TestClass(int param1, String param2)\n---\n",
-		},
+			{
+				name:     "generic interface",
+				code:     "interface Box<T> { T get(); void put(T item); }",
+				expected: "interface Box<T>\n\tT get();\n\tvoid put(T item);\n---\n",
+			},
+			{
+				name:     "generic interface with bounds",
+				code:     "interface Sortable<T extends Comparable<T>> { void sort(T[] items); }",
+				expected: "interface Sortable<T extends Comparable<T>>\n\tvoid sort(T[] items);\n---\n",
+			},
+			{
+				name:     "class with generic method",
+				code:     "class Util { public <T> void print(T item) {} }",
+				expected: "class Util\n\tpublic <T> void print(T item)\n---\n",
+			},
+			{
+				name:     "class with bounded generic method",
+				code:     "class NumberUtil { public <T extends Number> double sum(T[] numbers) {} }",
+				expected: "class NumberUtil\n\tpublic <T extends Number> double sum(T[] numbers)\n---\n",
+			},
+			{
+				name:     "class with multiple generic methods",
+				code:     "class Converter { public <T,R> R convert(T input) {} public <V> void validate(V value) {} }",
+				expected: "class Converter\n\tpublic <T,R> R convert(T input)\n\tpublic <V> void validate(V value)\n---\n",
+			},
 		*/
 		/*
-		{
-			name:     "class with method",
-			code:     "class TestClass { public void testMethod() {} }",
-			expected: "class TestClass\n\tpublic void testMethod()\n---\n",
-		},
-		{
-			name:     "class with multiple methods",
-			code:     "class TestClass { public void testMethod() {}\npublic void testMethod2() {} }",
-			expected: "class TestClass\n\tpublic void testMethod()\n\tpublic void testMethod2()\n---\n",
-		},
-		*/
-		/*
-		{
-			name:     "class with parameterized method",
-			code:     "class TestClass { public boolean testMethod(int param1, String param2) { return true; } }",
-			expected: "class TestClass\n\tpublic boolean testMethod(int param1, String param2)\n---\n",
-		},
-		{
-			name:     "class with private method",
-			code:     "class TestClass { private void testMethod() {} }",
-			expected: "class TestClass\n---\n",
-		},
-		{
-			name:     "class with comment",
-			code:     "// Test class comment\nclass TestClass {}",
-			expected: "class TestClass\n---\n",
-		},
-		*/
-		/*
-		{
-			name:     "multiple classes",
-			code:     "class Class1 {} class Class2 {}",
-			expected: "class Class1\n---\nclass Class2\n---\n",
-		},
-		{
-			name:     "annotation type declaration",
-			code:     "@interface TestAnnotation { String value(); int count() default 0; }",
-			expected: "@interface TestAnnotation\n\tString value();\n\tint count() default 0;\n---\n",
-		},
-		{
-			name:     "annotation type declaration with private method",
-			code:     "@interface TestAnnotation { String value(); private int count() default 0; }",
-			expected: "@interface TestAnnotation\n\tString value();\n---\n",
-		},
-		{
-			name:     "class with annotation",
-			code:     "@Test class TestClass {}",
-			expected: "@Test class TestClass\n---\n",
-		},
-		{
-			name:     "method with annotation",
-			code:     "class TestClass { @Override public void testMethod() {} }",
-			expected: "class TestClass\n\t@Override public void testMethod()\n---\n",
-		},
-		{
-			name:     "method argument with annotation",
-			code:     "class TestClass { public void testMethod(@NotNull String arg) {} }",
-			expected: "class TestClass\n\tpublic void testMethod(@NotNull String arg)\n---\n",
-		},
-		{
-			name:     "interface with annotation",
-			code:     "@FunctionalInterface interface TestInterface { void test(); }",
-			expected: "@FunctionalInterface interface TestInterface\n\tvoid test();\n---\n",
-		},
-		*/
-		/*
-		{
-			name:     "class with type parameter",
-			code:     "class Box<T> { }",
-			expected: "class Box<T>\n---\n",
-		},
-		{
-			name:     "class with bounded type parameter",
-			code:     "class NumberBox<T extends Number> { }",
-			expected: "class NumberBox<T extends Number>\n---\n",
-		},
-		{
-			name:     "class with multiple type parameters",
-			code:     "class Pair<K,V> { }",
-			expected: "class Pair<K,V>\n---\n",
-		},
-		{
-			name:     "class with complex type parameters",
-			code:     "class Container<T extends Comparable<T>> { }",
-			expected: "class Container<T extends Comparable<T>>\n---\n",
-		},
-		*/
-		/*
-		{
-			name:     "generic interface",
-			code:     "interface Box<T> { T get(); void put(T item); }",
-			expected: "interface Box<T>\n\tT get();\n\tvoid put(T item);\n---\n",
-		},
-		{
-			name:     "generic interface with bounds",
-			code:     "interface Sortable<T extends Comparable<T>> { void sort(T[] items); }",
-			expected: "interface Sortable<T extends Comparable<T>>\n\tvoid sort(T[] items);\n---\n",
-		},
-		{
-			name:     "class with generic method",
-			code:     "class Util { public <T> void print(T item) {} }",
-			expected: "class Util\n\tpublic <T> void print(T item)\n---\n",
-		},
-		{
-			name:     "class with bounded generic method",
-			code:     "class NumberUtil { public <T extends Number> double sum(T[] numbers) {} }",
-			expected: "class NumberUtil\n\tpublic <T extends Number> double sum(T[] numbers)\n---\n",
-		},
-		{
-			name:     "class with multiple generic methods",
-			code:     "class Converter { public <T,R> R convert(T input) {} public <V> void validate(V value) {} }",
-			expected: "class Converter\n\tpublic <T,R> R convert(T input)\n\tpublic <V> void validate(V value)\n---\n",
-		},
-		*/
-		/*
-		{
-			name:     "empty enum",
-			code:     "enum EmptyEnum {}",
-			expected: "enum EmptyEnum\n---\n",
-		},
-		{
-			name:     "enum with constants",
-			code:     "enum Direction { NORTH, SOUTH, EAST, WEST }",
-			expected: "enum Direction\n\tNORTH\n\tSOUTH\n\tEAST\n\tWEST\n---\n",
-		},
-		{
-			name:     "enum with public method",
-			code:     "enum Status { OK, ERROR; public String getMessage() { return null; } }",
-			expected: "enum Status\n\tOK\n\tERROR\n\tpublic String getMessage()\n---\n",
-		},
-		{
-			name:     "enum with private method",
-			code:     "enum Status { OK, ERROR; private String getMessage() { return null; } }",
-			expected: "enum Status\n\tOK\n\tERROR\n---\n",
-		},
-		{
-			name:     "enum with constants and multiple methods",
-			code:     "enum Complex { FIRST(1), SECOND(2); private final int value; private Complex(int value) { this.value = value; } public int getValue() { return value; } }",
-			expected: "enum Complex\n\tFIRST(1)\n\tSECOND(2)\n\tpublic int getValue()\n---\n",
-		},
-		{
-			name:     "annotated enum",
-			code:     "@Deprecated enum Legacy { OLD, OLDER }",
-			expected: "@Deprecated enum Legacy\n\tOLD\n\tOLDER\n---\n",
-		},
-		*/
-		/*
-		{
-			name: "nested class in class",
-			code: `
-public class OuterClass {
-    public static class StaticNestedClass {
-        public void nestedMethod() {}
-    }
-    protected class IgnoredNestedClass {}
-    private class AnotherIgnoredClass {}
-    public class PublicNestedClass {
-        public void method() {}
-    }
-}`,
-			expected: `public class OuterClass
----
-	public static class StaticNestedClass
-		public void nestedMethod()
----
-	public class PublicNestedClass
-		public void method()
----
-`,
-		},
-		{
-			name: "nested interface in class",
-			code: `
-public class OuterClass {
-    public interface NestedInterface {
-        void method();
-    }
-    private interface IgnoredInterface {}
-}`,
-			expected: `public class OuterClass
----
-	public interface NestedInterface
-		void method();
----
-`,
-		},
-		{
-			name: "nested annotation in class",
-			code: `
-public class OuterClass {
-    public @interface NestedAnnotation {
-        String value() default "";
-    }
-    private @interface IgnoredAnnotation {}
-}`,
-			expected: `public class OuterClass
----
-	public @interface NestedAnnotation
-		String value() default "";
----
-`,
-		},
-		{
-			name: "deeply nested types",
-			code: `
-public class OuterClass {
-    public class Level1 {
-        public interface Level2 {
-            public class Level3 {
-                void method();
-            }
-        }
-    }
-}`,
-			expected: `public class OuterClass
----
-	public class Level1
----
-		public interface Level2
----
-			public class Level3
-				void method()
----
-`,
-		},
-		{
-			name: "nested enum in class",
-			code: `
-public class Container {
-    public enum Status {
-        ACTIVE, INACTIVE;
-        public boolean isActive() { return this == ACTIVE; }
-    }
-    private enum Hidden { ONE, TWO }
-}`,
-			expected: `public class Container
----
-	public enum Status
-		ACTIVE
-		INACTIVE
-		public boolean isActive()
----
-`,
-		},
+				{
+					name:     "empty enum",
+					code:     "enum EmptyEnum {}",
+					expected: "enum EmptyEnum\n---\n",
+				},
+				{
+					name:     "enum with constants",
+					code:     "enum Direction { NORTH, SOUTH, EAST, WEST }",
+					expected: "enum Direction\n\tNORTH\n\tSOUTH\n\tEAST\n\tWEST\n---\n",
+				},
+				{
+					name:     "enum with public method",
+					code:     "enum Status { OK, ERROR; public String getMessage() { return null; } }",
+					expected: "enum Status\n\tOK\n\tERROR\n\tpublic String getMessage()\n---\n",
+				},
+				{
+					name:     "enum with private method",
+					code:     "enum Status { OK, ERROR; private String getMessage() { return null; } }",
+					expected: "enum Status\n\tOK\n\tERROR\n---\n",
+				},
+				{
+					name:     "enum with constants and multiple methods",
+					code:     "enum Complex { FIRST(1), SECOND(2); private final int value; private Complex(int value) { this.value = value; } public int getValue() { return value; } }",
+					expected: "enum Complex\n\tFIRST(1)\n\tSECOND(2)\n\tpublic int getValue()\n---\n",
+				},
+				{
+					name:     "annotated enum",
+					code:     "@Deprecated enum Legacy { OLD, OLDER }",
+					expected: "@Deprecated enum Legacy\n\tOLD\n\tOLDER\n---\n",
+				},
+				{
+					name: "nested class in class",
+					code: `
+		public class OuterClass {
+		    public static class StaticNestedClass {
+		        public void nestedMethod() {}
+		    }
+		    protected class IgnoredNestedClass {}
+		    private class AnotherIgnoredClass {}
+		    public class PublicNestedClass {
+		        public void method() {}
+		    }
+		}`,
+					expected: `public class OuterClass
+		---
+			public static class StaticNestedClass
+				public void nestedMethod()
+		---
+			public class PublicNestedClass
+				public void method()
+		---
+		`,
+				},
+				{
+					name: "nested interface in class",
+					code: `
+		public class OuterClass {
+		    public interface NestedInterface {
+		        void method();
+		    }
+		    private interface IgnoredInterface {}
+		}`,
+					expected: `public class OuterClass
+		---
+			public interface NestedInterface
+				void method();
+		---
+		`,
+				},
+				{
+					name: "nested annotation in class",
+					code: `
+		public class OuterClass {
+		    public @interface NestedAnnotation {
+		        String value() default "";
+		    }
+		    private @interface IgnoredAnnotation {}
+		}`,
+					expected: `public class OuterClass
+		---
+			public @interface NestedAnnotation
+				String value() default "";
+		---
+		`,
+				},
+				{
+					name: "deeply nested types",
+					code: `
+		public class OuterClass {
+		    public class Level1 {
+		        public interface Level2 {
+		            public class Level3 {
+		                void method();
+		            }
+		        }
+		    }
+		}`,
+					expected: `public class OuterClass
+		---
+			public class Level1
+		---
+				public interface Level2
+		---
+					public class Level3
+						void method()
+		---
+		`,
+				},
+				{
+					name: "nested enum in class",
+					code: `
+		public class Container {
+		    public enum Status {
+		        ACTIVE, INACTIVE;
+		        public boolean isActive() { return this == ACTIVE; }
+		    }
+		    private enum Hidden { ONE, TWO }
+		}`,
+					expected: `public class Container
+		---
+			public enum Status
+				ACTIVE
+				INACTIVE
+				public boolean isActive()
+		---
+		`,
+				},
 		*/
 	}
 
@@ -559,28 +548,27 @@ func TestGetFileSymbolsStringJava(t *testing.T) {
 		expected string
 	}{
 		/*
-		{
-			name: "simple class with method",
-			code: `
-public class Test {
-    public void testMethod() {
-        System.out.println("Hello");
-    }
-}`,
-			expected: "Test, testMethod",
-		},
-		{
-			name: "class with constructor",
-			code: `
-public class Person {
-    public Person(String name) {
-        // Constructor
-    }
-}`,
-			expected: "Person",
-		},
+				{
+					name: "simple class with method",
+					code: `
+		public class Test {
+		    public void testMethod() {
+		        System.out.println("Hello");
+		    }
+		}`,
+					expected: "Test, testMethod",
+				},
+				{
+					name: "class with constructor",
+					code: `
+		public class Person {
+		    public Person(String name) {
+		        // Constructor
+		    }
+		}`,
+					expected: "Person",
+				},
 		*/
-		/*
 		{
 			name:     "empty",
 			code:     "",
@@ -591,44 +579,42 @@ public class Person {
 			code:     "class Test {}",
 			expected: "Test",
 		},
+		/*
+				{
+					name: "class with private, public and protected fields",
+					code: `
+		public class TestClass {
+		    private int field1;
+		    public String field2;
+		    protected String field3;
+		}`,
+					expected: "TestClass",
+				},
 		*/
 		/*
-		{
-			name: "class with private, public and protected fields",
-			code: `
-public class TestClass {
-    private int field1;
-    public String field2;
-    protected String field3;
-}`,
-			expected: "TestClass",
-		},
+				{
+					name: "class with methods and fields",
+					code: `
+		public class Complex {
+		    private double real;
+		    private double imaginary;
+			public double x;
+
+		    public Complex add(Complex other) {
+		        return new Complex();
+		    }
+
+		    public Complex subtract(Complex other) {
+		        return new Complex();
+		    }
+
+		    private Complex internal(Complex other) {
+		        return new Complex();
+		    }
+		}`,
+					expected: "Complex, add, subtract",
+				},
 		*/
-		/*
-		{
-			name: "class with methods and fields",
-			code: `
-public class Complex {
-    private double real;
-    private double imaginary;
-	public double x;
-
-    public Complex add(Complex other) {
-        return new Complex();
-    }
-
-    public Complex subtract(Complex other) {
-        return new Complex();
-    }
-
-    private Complex internal(Complex other) {
-        return new Complex();
-    }
-}`,
-			expected: "Complex, add, subtract",
-		},
-		*/
-		/*
 		{
 			name: "interface declaration",
 			code: `
@@ -636,6 +622,7 @@ public interface Drawable {
     void draw();
     void resize();
 }`,
+			// Symbol should just be the interface name
 			expected: "Drawable",
 		},
 		{
@@ -645,118 +632,119 @@ public @interface TestAnnotation {
     String value() default "";
     int count() default 0;
 }`,
+			// Symbol should just be the annotation name
 			expected: "TestAnnotation",
 		},
-		*/
 		/*
-		{
-			name: "nested class",
-			code: `
-public class Outer {
-    private int x;
-    
-    public class Inner {
-        public void innerMethod() {
-            System.out.println("Inner method");
-        }
-    }
-    
-    public void outerMethod() {
-        System.out.println("Outer method");
-    }
-}`,
-			expected: "Outer, Inner, innerMethod, outerMethod",
-		},
-		{
-			name: "multiple classes in single file",
-			code: `
-class First {
-    public void firstMethod() {}
-}
+				{
+					name: "nested class",
+					code: `
+		public class Outer {
+		    private int x;
 
-class Second {
-    public void secondMethod() {}
-}
+		    public class Inner {
+		        public void innerMethod() {
+		            System.out.println("Inner method");
+		        }
+		    }
 
-class Third {
-    private void thirdMethod() {}
-}`,
-			expected: "First, firstMethod, Second, secondMethod, Third",
-		},
-		{
-			name: "class inheritance",
-			code: `
-public class Animal {
-    public void makeSound() {}
-}
+		    public void outerMethod() {
+		        System.out.println("Outer method");
+		    }
+		}`,
+					expected: "Outer, Inner, innerMethod, outerMethod",
+				},
+				{
+					name: "multiple classes in single file",
+					code: `
+		class First {
+		    public void firstMethod() {}
+		}
 
-public class Dog extends Animal {
-    public void bark() {}
-    private void sleep() {}
-}`,
-			expected: "Animal, makeSound, Dog, bark",
-		},
+		class Second {
+		    public void secondMethod() {}
+		}
+
+		class Third {
+		    private void thirdMethod() {}
+		}`,
+					expected: "First, firstMethod, Second, secondMethod, Third",
+				},
+				{
+					name: "class inheritance",
+					code: `
+		public class Animal {
+		    public void makeSound() {}
+		}
+
+		public class Dog extends Animal {
+		    public void bark() {}
+		    private void sleep() {}
+		}`,
+					expected: "Animal, makeSound, Dog, bark",
+				},
 		*/
-		/*
 		{
 			name: "basic enum",
 			code: `
 public enum Direction {
     NORTH, SOUTH, EAST, WEST
 }`,
+			// Symbol should just be the enum name. Constants handled later.
 			expected: "Direction",
 		},
-		{
-			name: "enum with methods",
-			code: `
-public enum Operation {
-    PLUS, MINUS, TIMES, DIVIDE;
-    
-    public double apply(double x, double y) {
-        return 0.0;
-    }
-    
-    private void helper() {
-        // Helper method
-    }
-}`,
-			expected: "Operation, apply",
-		},
-		{
-			name: "nested enum",
-			code: `
-public class Container {
-    public enum Status {
-        ACTIVE, INACTIVE, PENDING;
-        
-        public boolean isTerminal() {
-            return false;
-        }
-    }
-    
-    public void process() {
-        // Process method
-    }
-}`,
-			expected: "Container, Status, isTerminal, process",
-		},
+		/*
+				{
+					name: "enum with methods",
+					code: `
+		public enum Operation {
+		    PLUS, MINUS, TIMES, DIVIDE;
+
+		    public double apply(double x, double y) {
+		        return 0.0;
+		    }
+
+		    private void helper() {
+		        // Helper method
+		    }
+		}`,
+					expected: "Operation, apply",
+				},
+				{
+					name: "nested enum",
+					code: `
+		public class Container {
+		    public enum Status {
+		        ACTIVE, INACTIVE, PENDING;
+
+		        public boolean isTerminal() {
+		            return false;
+		        }
+		    }
+
+		    public void process() {
+		        // Process method
+		    }
+		}`,
+					expected: "Container, Status, isTerminal, process",
+				},
 		*/
 		/*
-		{
-			name: "multiple enums",
-			code: `
-enum Color {
-    RED, GREEN, BLUE;
-    public String getHex() { return ""; }
-}
+				{
+					name: "multiple enums",
+					code: `
+		enum Color {
+		    RED, GREEN, BLUE;
+		    public String getHex() { return ""; }
+		}
 
-enum Size {
-    SMALL, MEDIUM, LARGE;
-    public int getValue() { return 0; }
-    private void internal() {}
-}`,
-			expected: "Color, getHex, Size, getValue",
-		},
+		enum Size {
+		    SMALL, MEDIUM, LARGE;
+		    public int getValue() { return 0; }
+		    private void internal() {}
+		}`,
+					expected: "Color, getHex, Size, getValue",
+				},
 		*/
 	}
 

--- a/coding/tree_sitter/java_test.go
+++ b/coding/tree_sitter/java_test.go
@@ -198,241 +198,206 @@ func TestGetFileSignaturesStringJava(t *testing.T) {
 		{
 			name:     "empty interface",
 			code:     "interface TestInterface {}",
-			expected: "interface TestInterface", // Updated: No members
+			expected: "interface TestInterface",
 		},
 		{
-			name: "interface with method",
-			code: "interface TestInterface { void testMethod(); }",
-			// Interface + abstract method
+			name:     "interface with method",
+			code:     "interface TestInterface { void testMethod(); }",
 			expected: "interface TestInterface\n---\n\tvoid testMethod()",
 		},
 		{
-			name: "interface with multiple methods",
-			code: "interface TestInterface { void method1(); String method2(int param); }",
-			// Interface + abstract methods
+			name:     "interface with multiple methods",
+			code:     "interface TestInterface { void method1(); String method2(int param); }",
 			expected: "interface TestInterface\n---\n\tvoid method1()\n---\n\tString method2(int param)",
 		},
 		{
-			name: "public interface",
-			code: "public interface TestInterface { void method(); }",
-			// Interface + abstract method
+			name:     "public interface",
+			code:     "public interface TestInterface { void method(); }",
 			expected: "public interface TestInterface\n---\n\tvoid method()",
 		},
 		{
-			name: "interface with constant",
-			code: "interface TestInterface { public static final int CONSTANT = 42; void method(); }",
-			// Interface + constant + abstract method
+			name:     "interface with constant",
+			code:     "interface TestInterface { public static final int CONSTANT = 42; void method(); }",
 			expected: "interface TestInterface\n---\n\tpublic static final int CONSTANT\n---\n\tvoid method()",
 		},
 		{
 			name:     "empty",
 			code:     "",
-			expected: "", // Stays empty
+			expected: "",
 		},
 		{
 			name:     "simple class",
 			code:     "class TestClass {}",
-			expected: "class TestClass", // Updated: No members
+			expected: "class TestClass",
 		},
 		{
-			name: "class with public constant",
-			code: "class TestClass { public static final int CONSTANT = 42; }",
-			// Class + constant
+			name:     "class with public constant",
+			code:     "class TestClass { public static final int CONSTANT = 42; }",
 			expected: "class TestClass\n---\n\tpublic static final int CONSTANT",
 		},
 		{
-			name: "class with multiple constants",
-			code: "class TestClass { private static final int CONSTANT1 = 42; public static final int CONSTANT2 = 43; protected static final int CONSTANT3 = 44; }",
-			// Class + public constant
+			name:     "class with multiple constants",
+			code:     "class TestClass { private static final int CONSTANT1 = 42; public static final int CONSTANT2 = 43; protected static final int CONSTANT3 = 44; }",
 			expected: "class TestClass\n---\n\tpublic static final int CONSTANT2",
 		},
 		{
 			name:     "class with private field",
 			code:     "class TestClass { private int field; }",
-			expected: "class TestClass", // Updated: No public members
+			expected: "class TestClass",
 		},
 		{
-			name: "class with public field",
-			code: "class TestClass { public int field; }",
-			// Class + public field
+			name:     "class with public field",
+			code:     "class TestClass { public int field; }",
 			expected: "class TestClass\n---\n\tpublic int field",
 		},
 		{
-			name: "class with mixed fields",
-			code: "class TestClass { private int field1; public String field2; protected int field3; }",
-			// Class + public field
+			name:     "class with mixed fields",
+			code:     "class TestClass { private int field1; public String field2; protected int field3; }",
 			expected: "class TestClass\n---\n\tpublic String field2",
 		},
 		{
-			name: "class with constructor",
-			code: "class TestClass { public TestClass() {} }",
-			// Class + public constructor
+			name:     "class with constructor",
+			code:     "class TestClass { public TestClass() {} }",
 			expected: "class TestClass\n---\n\tpublic TestClass()",
 		},
 		{
-			name: "class with parameterized constructor",
-			code: "class TestClass { public TestClass(int param1, String param2) {} }",
-			// Class + public constructor
+			name:     "class with parameterized constructor",
+			code:     "class TestClass { public TestClass(int param1, String param2) {} }",
 			expected: "class TestClass\n---\n\tpublic TestClass(int param1, String param2)",
 		},
 		{
-			name: "class with method",
-			code: "class TestClass { public void testMethod() {} }",
-			// Class + public method
+			name:     "class with method",
+			code:     "class TestClass { public void testMethod() {} }",
 			expected: "class TestClass\n---\n\tpublic void testMethod()",
 		},
 		{
-			name: "class with multiple methods",
-			code: "class TestClass { public void testMethod() {}\\npublic void testMethod2() {} }",
-			// Class + public methods
+			name:     "class with multiple methods",
+			code:     "class TestClass { public void testMethod() {}\npublic void testMethod2() {} }",
 			expected: "class TestClass\n---\n\tpublic void testMethod()\n---\n\tpublic void testMethod2()",
 		},
 		{
-			name: "class with parameterized method",
-			code: "class TestClass { public boolean testMethod(int param1, String param2) { return true; } }",
-			// Class + public method
+			name:     "class with parameterized method",
+			code:     "class TestClass { public boolean testMethod(int param1, String param2) { return true; } }",
 			expected: "class TestClass\n---\n\tpublic boolean testMethod(int param1, String param2)",
 		},
 		{
 			name:     "class with private method",
 			code:     "class TestClass { private void testMethod() {} }",
-			expected: "class TestClass", // Updated: No public members
+			expected: "class TestClass",
 		},
 		{
 			name:     "class with comment",
 			code:     "// Test class comment\nclass TestClass {}",
-			expected: "class TestClass", // Updated: No members, comment ignored
+			expected: "class TestClass",
 		},
 		{
-			name: "multiple classes",
-			code: "class Class1 {} class Class2 {}",
-			// Both classes are package-private
+			name:     "multiple classes",
+			code:     "class Class1 {} class Class2 {}",
 			expected: "class Class1\n---\nclass Class2",
 		},
-		{ // Annotation type declaration was already uncommented in Step 1, just verify expected
-			name: "annotation type declaration",
-			code: "@interface TestAnnotation { String value(); int count() default 0; }",
-			// Annotation + elements
+		{
+			name:     "annotation type declaration",
+			code:     "@interface TestAnnotation { String value(); int count() default 0; }",
 			expected: "@interface TestAnnotation\n---\n\tString value();\n---\n\tint count() default 0;",
 		},
-		/* // Keep private method version commented
 		{
 			name:     "annotation type declaration with private method",
 			code:     "@interface TestAnnotation { String value(); private int count() default 0; }",
-			expected: "@interface TestAnnotation\n\tString value();\n---\n",
+			expected: "@interface TestAnnotation\n---\n\tString value();",
 		},
-		*/
 		{
-			name: "class with annotation",
-			code: "@Test class TestClass {}",
-			// Annotation is part of signature
+			name:     "class with annotation",
+			code:     "@Test class TestClass {}",
 			expected: "@Test class TestClass",
 		},
 		{
-			name: "method with annotation",
-			code: "class TestClass { @Override public void testMethod() {} }",
-			// Class + annotated method
+			name:     "method with annotation",
+			code:     "class TestClass { @Override public void testMethod() {} }",
 			expected: "class TestClass\n---\n\t@Override public void testMethod()",
 		},
 		{
-			name: "method argument with annotation",
-			code: "class TestClass { public void testMethod(@NotNull String arg) {} }",
-			// Class + method with annotated arg
+			name:     "method argument with annotation",
+			code:     "class TestClass { public void testMethod(@NotNull String arg) {} }",
 			expected: "class TestClass\n---\n\tpublic void testMethod(@NotNull String arg)",
 		},
 		{
-			name: "interface with annotation",
-			code: "@FunctionalInterface interface TestInterface { void test(); }",
-			// Annotated interface + abstract method
+			name:     "interface with annotation",
+			code:     "@FunctionalInterface interface TestInterface { void test(); }",
 			expected: "@FunctionalInterface interface TestInterface\n---\n\tvoid test()",
 		},
 		{
-			name: "class with type parameter",
-			code: "class Box<T> { }",
-			// Generic class
+			name:     "class with type parameter",
+			code:     "class Box<T> { }",
 			expected: "class Box<T>",
 		},
 		{
-			name: "class with bounded type parameter",
-			code: "class NumberBox<T extends Number> { }",
-			// Generic class with bounds
+			name:     "class with bounded type parameter",
+			code:     "class NumberBox<T extends Number> { }",
 			expected: "class NumberBox<T extends Number>",
 		},
 		{
-			name: "class with multiple type parameters",
-			code: "class Pair<K, V> { }",
-			// Generic class with multiple params
-			expected: "class Pair<K, V>", // Note: Adjusted spacing based on go-tree-sitter output
+			name:     "class with multiple type parameters",
+			code:     "class Pair<K, V> { }",
+			expected: "class Pair<K, V>",
 		},
 		{
-			name: "class with complex type parameters",
-			code: "class Container<T extends Comparable<T>> { }",
-			// Generic class with complex bounds
+			name:     "class with complex type parameters",
+			code:     "class Container<T extends Comparable<T>> { }",
 			expected: "class Container<T extends Comparable<T>>",
 		},
 		{
-			name: "generic interface",
-			code: "interface Box<T> { T get(); void put(T item); }",
-			// Generic interface + abstract methods
+			name:     "generic interface",
+			code:     "interface Box<T> { T get(); void put(T item); }",
 			expected: "interface Box<T>\n---\n\tT get()\n---\n\tvoid put(T item)",
 		},
 		{
-			name: "generic interface with bounds",
-			code: "interface Sortable<T extends Comparable<T>> { void sort(T[] items); }",
-			// Generic interface + abstract method
+			name:     "generic interface with bounds",
+			code:     "interface Sortable<T extends Comparable<T>> { void sort(T[] items); }",
 			expected: "interface Sortable<T extends Comparable<T>>\n---\n\tvoid sort(T[] items)",
 		},
 		{
-			name: "class with generic method",
-			code: "class Util { public <T> void print(T item) {} }",
-			// Class + generic method
+			name:     "class with generic method",
+			code:     "class Util { public <T> void print(T item) {} }",
 			expected: "class Util\n---\n\tpublic <T> void print(T item)",
 		},
 		{
-			name: "class with bounded generic method",
-			code: "class NumberUtil { public <T extends Number> double sum(T[] numbers) {} }",
-			// Class + bounded generic method
+			name:     "class with bounded generic method",
+			code:     "class NumberUtil { public <T extends Number> double sum(T[] numbers) {} }",
 			expected: "class NumberUtil\n---\n\tpublic <T extends Number> double sum(T[] numbers)",
 		},
 		{
-			name: "class with multiple generic methods",
-			code: "class Converter { public <T, R> R convert(T input) {} public <V> void validate(V value) {} }",
-			// Class + generic methods
-			expected: "class Converter\n---\n\tpublic <T, R> R convert(T input)\n---\n\tpublic <V> void validate(V value)", // Note: Adjusted spacing
+			name:     "class with multiple generic methods",
+			code:     "class Converter { public <T, R> R convert(T input) {} public <V> void validate(V value) {} }",
+			expected: "class Converter\n---\n\tpublic <T, R> R convert(T input)\n---\n\tpublic <V> void validate(V value)",
 		},
 		{
 			name:     "empty enum",
 			code:     "enum EmptyEnum {}",
-			expected: "enum EmptyEnum", // Updated: No members
+			expected: "enum EmptyEnum",
 		},
 		{
-			name: "enum with constants",
-			code: "enum Direction { NORTH, SOUTH, EAST, WEST }",
-			// Enum + constants
+			name:     "enum with constants",
+			code:     "enum Direction { NORTH, SOUTH, EAST, WEST }",
 			expected: "enum Direction\n---\n\tNORTH\n---\n\tSOUTH\n---\n\tEAST\n---\n\tWEST",
 		},
 		{
-			name: "enum with public method",
-			code: "enum Status { OK, ERROR; public String getMessage() { return null; } }",
-			// Enum + constants + public method
+			name:     "enum with public method",
+			code:     "enum Status { OK, ERROR; public String getMessage() { return null; } }",
 			expected: "enum Status\n---\n\tOK\n---\n\tERROR\n---\n\tpublic String getMessage()",
 		},
 		{
-			name: "enum with private method",
-			code: "enum Status { OK, ERROR; private String getMessage() { return null; } }",
-			// Enum + constants (private method ignored)
+			name:     "enum with private method",
+			code:     "enum Status { OK, ERROR; private String getMessage() { return null; } }",
 			expected: "enum Status\n---\n\tOK\n---\n\tERROR",
 		},
 		{
-			name: "enum with constants and multiple methods",
-			code: "enum Complex { FIRST(1), SECOND(2); private final int value; private Complex(int value) { this.value = value; } public int getValue() { return value; } }",
-			// Enum + constants + public method (private constructor/field ignored)
-			expected: "enum Complex\n---\n\tFIRST\n---\n\tSECOND\n---\n\tpublic int getValue()", // Note: Constructor args (1), (2) not part of signature
+			name:     "enum with constants and multiple methods",
+			code:     "enum Complex { FIRST(1), SECOND(2); private final int value; private Complex(int value) { this.value = value; } public int getValue() { return value; } }",
+			expected: "enum Complex\n---\n\tFIRST\n---\n\tSECOND\n---\n\tpublic int getValue()",
 		},
 		{
-			name: "annotated enum",
-			code: "@Deprecated enum Legacy { OLD, OLDER }",
-			// Annotated enum + constants
+			name:     "annotated enum",
+			code:     "@Deprecated enum Legacy { OLD, OLDER }",
 			expected: "@Deprecated enum Legacy\n---\n\tOLD\n---\n\tOLDER",
 		},
 		{
@@ -447,7 +412,7 @@ public class OuterClass {
     public class PublicNestedClass { // Public inner
         public void method() {}
     }
-}`, // Outer class + public static nested class + method + public inner class + method
+}`,
 			expected: "public class OuterClass\n---\n\tpublic static class StaticNestedClass\n---\n\t\tpublic void nestedMethod()\n---\n\tpublic class PublicNestedClass\n---\n\t\tpublic void method()",
 		},
 		{
@@ -458,7 +423,7 @@ public class OuterClass {
         void method(); // Abstract method
     }
     private interface IgnoredInterface {} // Private nested interface
-}`, // Outer class + public nested interface + abstract method
+}`,
 			expected: "public class OuterClass\n---\n\tpublic interface NestedInterface\n---\n\t\tvoid method()",
 		},
 		{
@@ -469,7 +434,7 @@ public class OuterClass {
         String value() default ""; // Element
     }
     private @interface IgnoredAnnotation {} // Private nested annotation
-}`, // Outer class + public nested annotation + element
+}`,
 			expected: "public class OuterClass\n---\n\tpublic @interface NestedAnnotation\n---\n\t\tString value() default \"\";",
 		},
 		{
@@ -483,7 +448,7 @@ public class OuterClass {
             }
         }
     }
-}`, // Outer + L1 + L2 + L3 + method
+}`,
 			expected: "public class OuterClass\n---\n\tpublic class Level1\n---\n\t\tpublic interface Level2\n---\n\t\t\tpublic class Level3\n---\n\t\t\t\tvoid method()",
 		},
 		{
@@ -495,7 +460,7 @@ public class Container {
         public boolean isActive() { return this == ACTIVE; } // Public method
     }
     private enum Hidden { ONE, TWO } // Private nested enum
-}`, // Container + Status enum + constants + method
+}`,
 			expected: "public class Container\n---\n\tpublic enum Status\n---\n\t\tACTIVE\n---\n\t\tINACTIVE\n---\n\t\tpublic boolean isActive()",
 		},
 	}
@@ -525,10 +490,11 @@ public class Container {
 			// we don't care about the last spearator really, we'd ideall leave
 			// it out but the implementation today has it and we strip it away
 			// later anyways
-			result = strings.TrimSuffix(result, "\n---\n")
+			result = strings.TrimSuffix(result, "\n---\n") // Corrected escaping
 
 			// Check the result
 			if result != tc.expected {
+				// Corrected escaping in format string
 				t.Errorf("GetFileSignatures returned incorrect result. Expected:\n%s\nGot:\n%s", tc.expected, result)
 			}
 		})
@@ -549,7 +515,7 @@ public class Test {
         System.out.println("Hello");
     }
 }`,
-			expected: "Test, testMethod", // Updated: Newline separated
+			expected: "Test, testMethod",
 		},
 		{
 			name: "class with constructor",
@@ -579,7 +545,7 @@ public class TestClass {
     public String field2;
     protected String field3;
 }`,
-			expected: "TestClass, field2", // Updated: Only public field included
+			expected: "TestClass, field2",
 		},
 		{
 			name: "class with methods and fields",
@@ -601,7 +567,7 @@ public class Complex {
         return new Complex();
     }
 }`,
-			expected: "Complex, x, add, subtract", // Updated: Public field and methods
+			expected: "Complex, x, add, subtract",
 		},
 		{
 			name: "interface declaration",
@@ -610,8 +576,7 @@ public interface Drawable {
     void draw();
     void resize(); // Implicitly public abstract
 }`,
-			// Symbol should include interface name and its abstract methods
-			expected: "Drawable, draw, resize", // Updated: Include method names
+			expected: "Drawable, draw, resize",
 		},
 		{
 			name: "annotation declaration",
@@ -620,8 +585,7 @@ public @interface TestAnnotation {
     String value() default "";
     int count() default 0; // Implicitly public abstract
 }`,
-			// Symbol should include annotation name and its elements
-			expected: "TestAnnotation, value, count", // Updated: Include element names
+			expected: "TestAnnotation, value, count",
 		},
 		{
 			name: "nested class",
@@ -639,8 +603,7 @@ public class Outer {
         System.out.println("Outer method");
     }
 }`,
-			// Expected: Outer class, its public method, inner class, its public method
-			expected: "Outer, Inner, innerMethod, outerMethod", // Updated: Newline separated
+			expected: "Outer, Inner, innerMethod, outerMethod",
 		},
 		{
 			name: "multiple classes in single file",
@@ -656,8 +619,7 @@ class Second { // Package-private
 class Third { // Package-private
     private void thirdMethod() {} // Private method
 }`,
-			// Expected: All package-private classes and their public methods
-			expected: "First, firstMethod, Second, secondMethod, Third", // Updated: Newline separated
+			expected: "First, firstMethod, Second, secondMethod, Third",
 		},
 		{
 			name: "class inheritance",
@@ -670,8 +632,7 @@ public class Dog extends Animal {
     public void bark() {}
     private void sleep() {} // Private method
 }`,
-			// Expected: Both public classes and their public methods
-			expected: "Animal, makeSound, Dog, bark", // Updated: Newline separated
+			expected: "Animal, makeSound, Dog, bark",
 		},
 		{
 			name: "basic enum",
@@ -679,8 +640,7 @@ public class Dog extends Animal {
 public enum Direction {
     NORTH, SOUTH, EAST, WEST // Implicitly public static final
 }`,
-			// Symbol should include enum name and its constants
-			expected: "Direction, NORTH, SOUTH, EAST, WEST", // Updated: Include constants
+			expected: "Direction, NORTH, SOUTH, EAST, WEST",
 		},
 		{
 			name: "enum with methods",
@@ -696,8 +656,7 @@ public enum Operation {
         // Helper method
     }
 }`,
-			// Expected: Enum name, constants, public method
-			expected: "Operation, PLUS, MINUS, TIMES, DIVIDE, apply", // Updated: Include constants and method
+			expected: "Operation, PLUS, MINUS, TIMES, DIVIDE, apply",
 		},
 		{
 			name: "nested enum",
@@ -715,8 +674,7 @@ public class Container {
         // Process method
     }
 }`,
-			// Expected: Outer class, its method, nested enum, its constants, its method
-			expected: "Container, Status, ACTIVE, INACTIVE, PENDING, isTerminal, process", // Updated: Include all public/default members
+			expected: "Container, Status, ACTIVE, INACTIVE, PENDING, isTerminal, process",
 		},
 		{
 			name: "multiple enums",
@@ -731,8 +689,7 @@ enum Size { // Package-private enum
     public int getValue() { return 0; } // Public method
     private void internal() {} // Private method
 }`,
-			// Expected: Both enums, their constants, their public methods
-			expected: "Color, RED, GREEN, BLUE, getHex, Size, SMALL, MEDIUM, LARGE, getValue", // Updated: Include all public/default members
+			expected: "Color, RED, GREEN, BLUE, getHex, Size, SMALL, MEDIUM, LARGE, getValue",
 		},
 	}
 
@@ -1058,7 +1015,7 @@ public enum DocEnum {
 			    int count() default 0; // Implicitly public abstract
 			}`,
 						// Symbol should include annotation name and its elements
-						expected: "TestAnnotation, value, count", // Updated: Include element names
+						expected: "TestAnnotation, value, count",
 					},
 		*/
 

--- a/coding/tree_sitter/java_test.go
+++ b/coding/tree_sitter/java_test.go
@@ -195,6 +195,7 @@ func TestGetFileSignaturesStringJava(t *testing.T) {
 		code     string
 		expected string
 	}{
+		/*
 		{
 			name:     "empty interface",
 			code:     "interface TestInterface {}",
@@ -215,6 +216,8 @@ func TestGetFileSignaturesStringJava(t *testing.T) {
 			code:     "public interface TestInterface { void method(); }",
 			expected: "public interface TestInterface\n\tvoid method();\n---\n",
 		},
+		*/
+		/*
 		{
 			name:     "interface with constant",
 			code:     "interface TestInterface { public static final int CONSTANT = 42; void method(); }",
@@ -230,6 +233,8 @@ func TestGetFileSignaturesStringJava(t *testing.T) {
 			code:     "class TestClass {}",
 			expected: "class TestClass\n---\n",
 		},
+		*/
+		/*
 		{
 			name:     "class with public constant",
 			code:     "class TestClass { public static final int CONSTANT = 42; }",
@@ -255,6 +260,8 @@ func TestGetFileSignaturesStringJava(t *testing.T) {
 			code:     "class TestClass { private int field1; public String field2; protected int field3; }",
 			expected: "class TestClass\n\tpublic String field2;\n---\n",
 		},
+		*/
+		/*
 		{
 			name:     "class with constructor",
 			code:     "class TestClass { public TestClass() {} }",
@@ -265,6 +272,8 @@ func TestGetFileSignaturesStringJava(t *testing.T) {
 			code:     "class TestClass { public TestClass(int param1, String param2) {} }",
 			expected: "class TestClass\n\tpublic TestClass(int param1, String param2)\n---\n",
 		},
+		*/
+		/*
 		{
 			name:     "class with method",
 			code:     "class TestClass { public void testMethod() {} }",
@@ -275,6 +284,8 @@ func TestGetFileSignaturesStringJava(t *testing.T) {
 			code:     "class TestClass { public void testMethod() {}\npublic void testMethod2() {} }",
 			expected: "class TestClass\n\tpublic void testMethod()\n\tpublic void testMethod2()\n---\n",
 		},
+		*/
+		/*
 		{
 			name:     "class with parameterized method",
 			code:     "class TestClass { public boolean testMethod(int param1, String param2) { return true; } }",
@@ -290,6 +301,8 @@ func TestGetFileSignaturesStringJava(t *testing.T) {
 			code:     "// Test class comment\nclass TestClass {}",
 			expected: "class TestClass\n---\n",
 		},
+		*/
+		/*
 		{
 			name:     "multiple classes",
 			code:     "class Class1 {} class Class2 {}",
@@ -325,6 +338,8 @@ func TestGetFileSignaturesStringJava(t *testing.T) {
 			code:     "@FunctionalInterface interface TestInterface { void test(); }",
 			expected: "@FunctionalInterface interface TestInterface\n\tvoid test();\n---\n",
 		},
+		*/
+		/*
 		{
 			name:     "class with type parameter",
 			code:     "class Box<T> { }",
@@ -345,6 +360,8 @@ func TestGetFileSignaturesStringJava(t *testing.T) {
 			code:     "class Container<T extends Comparable<T>> { }",
 			expected: "class Container<T extends Comparable<T>>\n---\n",
 		},
+		*/
+		/*
 		{
 			name:     "generic interface",
 			code:     "interface Box<T> { T get(); void put(T item); }",
@@ -370,6 +387,8 @@ func TestGetFileSignaturesStringJava(t *testing.T) {
 			code:     "class Converter { public <T,R> R convert(T input) {} public <V> void validate(V value) {} }",
 			expected: "class Converter\n\tpublic <T,R> R convert(T input)\n\tpublic <V> void validate(V value)\n---\n",
 		},
+		*/
+		/*
 		{
 			name:     "empty enum",
 			code:     "enum EmptyEnum {}",
@@ -400,6 +419,8 @@ func TestGetFileSignaturesStringJava(t *testing.T) {
 			code:     "@Deprecated enum Legacy { OLD, OLDER }",
 			expected: "@Deprecated enum Legacy\n\tOLD\n\tOLDER\n---\n",
 		},
+		*/
+		/*
 		{
 			name: "nested class in class",
 			code: `
@@ -497,6 +518,7 @@ public class Container {
 ---
 `,
 		},
+		*/
 	}
 
 	for _, tc := range testCases {
@@ -536,6 +558,7 @@ func TestGetFileSymbolsStringJava(t *testing.T) {
 		code     string
 		expected string
 	}{
+		/*
 		{
 			name: "simple class with method",
 			code: `
@@ -556,6 +579,8 @@ public class Person {
 }`,
 			expected: "Person",
 		},
+		*/
+		/*
 		{
 			name:     "empty",
 			code:     "",
@@ -566,6 +591,8 @@ public class Person {
 			code:     "class Test {}",
 			expected: "Test",
 		},
+		*/
+		/*
 		{
 			name: "class with private, public and protected fields",
 			code: `
@@ -576,6 +603,8 @@ public class TestClass {
 }`,
 			expected: "TestClass",
 		},
+		*/
+		/*
 		{
 			name: "class with methods and fields",
 			code: `
@@ -598,6 +627,8 @@ public class Complex {
 }`,
 			expected: "Complex, add, subtract",
 		},
+		*/
+		/*
 		{
 			name: "interface declaration",
 			code: `
@@ -616,6 +647,8 @@ public @interface TestAnnotation {
 }`,
 			expected: "TestAnnotation",
 		},
+		*/
+		/*
 		{
 			name: "nested class",
 			code: `
@@ -663,6 +696,8 @@ public class Dog extends Animal {
 }`,
 			expected: "Animal, makeSound, Dog, bark",
 		},
+		*/
+		/*
 		{
 			name: "basic enum",
 			code: `
@@ -705,6 +740,8 @@ public class Container {
 }`,
 			expected: "Container, Status, isTerminal, process",
 		},
+		*/
+		/*
 		{
 			name: "multiple enums",
 			code: `
@@ -720,6 +757,7 @@ enum Size {
 }`,
 			expected: "Color, getHex, Size, getValue",
 		},
+		*/
 	}
 
 	for _, test := range tests {

--- a/coding/tree_sitter/signature_queries/signature_java.scm
+++ b/coding/tree_sitter/signature_queries/signature_java.scm
@@ -177,6 +177,7 @@
   (annotation_type_body
     (annotation_type_element_declaration
       (modifiers)? @annotation_type_element.modifiers
+        (#not-match? @annotation_type_element.modifiers "(private|protected)")
       type: (_) @annotation_type_element.type
       name: (identifier) @annotation_type_element.name
       ; No explicit visibility check needed, implicitly public abstract

--- a/coding/tree_sitter/signature_queries/signature_java.scm
+++ b/coding/tree_sitter/signature_queries/signature_java.scm
@@ -44,15 +44,15 @@
   (modifiers)? @method.class.modifiers ; For parent visibility predicate check
   (class_body
     (method_declaration
-      (modifiers)? @method.modifiers ; Modifiers for signature
-        (#not-match? @method.modifiers "(private|protected)") ; Check method visibility
+      (modifiers)? @method.modifiers
+        (#not-match? @method.modifiers "(private|protected)")
       (type_parameters)? @method.type_parameters
-      type: (_) @method.type ; Return type
+      type: (_) @method.type
       name: (identifier) @method.name ; Hierarchical and simple name
-      parameters: (_) @method.parameters ; Parameters
+      parameters: (_) @method.parameters
     ) @method.declaration ; Capture the whole method for signature context
   )
-  (#not-match? @method.class.modifiers "(private|protected)") ; Check class visibility
+  (#not-match? @method.class.modifiers "(private|protected)")
 )
 
 ;; Methods in Interfaces (default or static - abstract methods are part of interface decl)
@@ -69,7 +69,7 @@
       parameters: (_) @method.parameters
     ) @method.declaration
   )
-  (#not-match? @method.interface.modifiers "(private|protected)") ; Check interface visibility
+  (#not-match? @method.interface.modifiers "(private|protected)")
 )
 
 ;; Methods in Enums
@@ -83,11 +83,11 @@
         type: (_) @method.type
         name: (identifier) @method.name
         parameters: (_) @method.parameters
-        (#not-match? @method.modifiers "(private|protected)") ; Check method visibility
+        (#not-match? @method.modifiers "(private|protected)")
       ) @method.declaration
     )
   )
-  (#not-match? @method.enum.modifiers "(private|protected)") ; Check enum visibility
+  (#not-match? @method.enum.modifiers "(private|protected)")
 )
 
 ;; Constructors in Classes
@@ -95,13 +95,13 @@
   (modifiers)? @constructor.class.modifiers ; For parent visibility predicate check
   (class_body
     (constructor_declaration
-      (modifiers)? @constructor.modifiers ; Modifiers for signature
+      (modifiers)? @constructor.modifiers
       name: (identifier) @constructor.name
-      parameters: (_) @constructor.parameters ; Parameters
-      (#not-match? @constructor.modifiers "(private|protected)") ; Check: constructor visibility
+      parameters: (_) @constructor.parameters
+      (#not-match? @constructor.modifiers "(private|protected)")
     ) @constructor.declaration ; Capture the whole constructor
   )
-  (#not-match? @constructor.class.modifiers "(private|protected)") ; Check class visibility
+  (#not-match? @constructor.class.modifiers "(private|protected)")
 )
 
 ;; fields/constants in Classes (captures each declarator)
@@ -109,17 +109,17 @@
   (modifiers)? @field.class.modifiers ; For parent visibility predicate check
   (class_body
     (field_declaration
-      (modifiers)? @field.modifiers ; Modifiers for the whole declaration
-      type: (_) @field.type ; Type for the whole declaration
+      (modifiers)? @field.modifiers
+      type: (_) @field.type
       (variable_declarator
         name: (identifier) @field.name
-        value: (_)? @field.value ; Optional value
-        dimensions: (_)? @field.dimensions ; Optional array dimensions on declarator
+        value: (_)? @field.value
+        dimensions: (_)? @field.dimensions
       ) @declarator ; Capture each declarator
-      (#not-match? @field.modifiers "(private|protected)") ; Check field visibility based on declaration modifiers
+      (#not-match? @field.modifiers "(private|protected)")
     ) @field.declaration ; Capture the whole field declaration (match per declarator)
   )
-  (#not-match? @field.class.modifiers "(private|protected)") ; Check class visibility
+  (#not-match? @field.class.modifiers "(private|protected)")
 )
 
 ;; Constants in Interfaces (captures each declarator)
@@ -127,7 +127,7 @@
   (modifiers)? @constant.interface.modifiers ; For parent visibility predicate check
   (interface_body
     (constant_declaration ; Constants in interfaces are implicitly public static final
-      (modifiers)? @constant.modifiers ; Modifiers for the whole declaration
+      (modifiers)? @constant.modifiers
       type: (_) @constant.type
       (variable_declarator
         name: (identifier) @constant.name
@@ -137,7 +137,7 @@
       ; No visibility check needed, implicitly public
     ) @constant.declaration
   )
-  (#not-match? @constant.interface.modifiers "(private|protected)") ; Check interface visibility
+  (#not-match? @constant.interface.modifiers "(private|protected)")
 )
 
 ;; Enum Constants
@@ -145,13 +145,13 @@
   (modifiers)? @constant.enum.modifiers ; For parent visibility predicate check
   (enum_body
     (enum_constant
-      (modifiers)? @constant.modifiers ; Modifiers for the whole declaration
+      (modifiers)? @constant.modifiers
       name: (identifier) @constant.name ; Hierarchical and simple name
-      arguments: (_)? @constant.arguments ; Optional arguments
+      arguments: (_)? @constant.arguments
     ) @constant.declaration ; Capture the constant
     ; No explicit visibility check needed for enum constants, they are implicitly public static final
   )
-  (#not-match? @constant.enum.modifiers "(private|protected)") ; Check enum visibility
+  (#not-match? @constant.enum.modifiers "(private|protected)")
 )
 
 ;; Annotation Type Constants
@@ -159,7 +159,7 @@
   (modifiers)? @constant.annotation.modifiers ; For parent visibility predicate check
   (annotation_type_body
     (constant_declaration
-      (modifiers)? @constant.modifiers ; Modifiers for the whole declaration
+      (modifiers)? @constant.modifiers
       type: (_) @constant.type
       (variable_declarator
         name: (identifier) @constant.name
@@ -168,7 +168,7 @@
       ) @declarator
     ) @constant.declaration
   )
-  (#not-match? @constant.annotation.modifiers "(private|protected)") ; Check annotation visibility
+  (#not-match? @constant.annotation.modifiers "(private|protected)")
 )
 
 ;; Annotation Type Elements
@@ -176,11 +176,11 @@
   (modifiers)? @annotation_type_element.annotation.modifiers ; For parent visibility predicate check
   (annotation_type_body
     (annotation_type_element_declaration
-      (modifiers)? @annotation_type_element.modifiers ; Modifiers (usually public abstract)
-      type: (_) @annotation_type_element.type ; Type
+      (modifiers)? @annotation_type_element.modifiers
+      type: (_) @annotation_type_element.type
       name: (identifier) @annotation_type_element.name
       ; No explicit visibility check needed, implicitly public abstract
     ) @annotation_type_element.declaration ; Capture the element
   )
-  (#not-match? @annotation_type_element.annotation.modifiers "(private|protected)") ; Check annotation visibility
+  (#not-match? @annotation_type_element.annotation.modifiers "(private|protected)")
 )

--- a/coding/tree_sitter/signature_queries/signature_java.scm
+++ b/coding/tree_sitter/signature_queries/signature_java.scm
@@ -1,183 +1,187 @@
-(interface_declaration
-  (modifiers)? @interface.modifiers
-    (#not-match? @interface.modifiers "private|protected")
-  (identifier) @interface.name
-  (type_parameters)? @interface.type_parameters
-    body: (_
-      [
-        (method_declaration) @interface.method.declaration
-        (constant_declaration) @interface.constant.declaration
-        (field_declaration) @interface.field.declaration
-        (_)
-      ]*
-    ) @interface.body
-) @interface.declaration
-
-(annotation_type_declaration
-  (modifiers)? @annotation.modifiers
-    (#not-match? @annotation.modifiers "private|protected")
-  (identifier) @annotation.name
-    body: (_
-      [
-        (annotation_type_element_declaration
-          (modifiers)? @annotation.element.modifiers
-            (#not-match? @annotation.element.modifiers "private|protected")
-          type: (_) @annotation.element.type
-          (identifier) @annotation.element.name
-        ) @annotation.element.declaration
-
-        (annotation_type_element_declaration
-          (modifiers)? @annotation.element.ignore.modifiers
-            (#match? @annotation.element.ignore.modifiers "private|protected")
-        )
-
-        (constant_declaration) @annotation.constant.declaration
-
-        (_)
-      ]*
-    ) @annotation.body
-) @annotation.declaration
-
-(class_declaration
-  (modifiers)? @class.modifiers
-    (#not-match? @class.modifiers "private|protected")
-  (identifier) @class.name
-  (type_parameters)? @class.type_parameters
-    body: (_
-      [
-        (method_declaration
-          (modifiers)? @class.method.modifiers
-            (#not-match? @class.method.modifiers "private|protected")
-          (type_parameters)? @class.method.type_parameters
-          type: (_) @class.method.type
-          (identifier) @class.method.name
-          (formal_parameters) @class.method.parameters
-        ) @class.method.declaration
-
-        (method_declaration
-          (modifiers)? @class.method.ignored.modifiers
-            (#match? @class.method.ignored.modifiers "private|protected")
-        )
-
-        (constructor_declaration
-          (modifiers)? @class.constructor.modifiers
-            (#not-match? @class.constructor.modifiers "private|protected")
-          (identifier) @class.constructor.name
-          (formal_parameters) @class.constructor.parameters
-        ) @class.constructor.declaration
-
-        (constructor_declaration
-          (modifiers)? @class.constructor.ignored.modifiers
-            (#match? @class.constructor.ignored.modifiers "private|protected")
-        )
-
-        (field_declaration
-          (modifiers)? @class.field.modifiers
-            (#not-match? @class.field.modifiers "private|protected")
-          (variable_declarator
-            (identifier) @class.field.name
-          )
-        ) @class.field.declaration
-
-        (field_declaration
-          (modifiers)? @class.field.ignored.modifiers
-            (#match? @class.field.ignored.modifiers "private|protected")
-        ) @class.field.ignored.declaration
-
-        (constant_declaration
-          (modifiers)? @class.constant.modifiers
-            (#not-match? @class.constant.modifiers "private|protected")
-          (variable_declarator
-            (identifier) @class.constant.name
-          )
-        ) @class.constant.declaration
-
-        (constant_declaration
-          (modifiers)? @class.constant.ignored.modifiers
-            (#match? @class.constant.ignored.modifiers "private|protected")
-        ) @class.constant.ignored.declaration
-
-        (_)
-      ]*
-    ) @class.body
-) @class.declaration
-
-(enum_declaration
-  (modifiers)? @enum.modifiers
-    (#not-match? @enum.modifiers "private|protected")
-  (identifier) @enum.name
-  body: (_
-    ; bug in tree-sitter means * isn't working here, so hard-coding many with ? instead
-    (enum_constant)? @enum.constant.declaration
-    (enum_constant)? @enum.constant.declaration
-    (enum_constant)? @enum.constant.declaration
-    (enum_constant)? @enum.constant.declaration
-    (enum_constant)? @enum.constant.declaration
-    (enum_constant)? @enum.constant.declaration
-    (enum_constant)? @enum.constant.declaration
-    (enum_constant)? @enum.constant.declaration
-    (enum_constant)? @enum.constant.declaration
-    (enum_constant)? @enum.constant.declaration
-    (enum_constant)? @enum.constant.declaration
-    (enum_constant)? @enum.constant.declaration
-    (enum_constant)? @enum.constant.declaration
-    (enum_constant)? @enum.constant.declaration
-    (enum_constant)? @enum.constant.declaration
-    (enum_constant)? @enum.constant.declaration
-    (enum_body_declarations
-      [
-        (method_declaration
-          (modifiers)? @enum.method.modifiers
-            (#not-match? @enum.method.modifiers "private|protected")
-          type: (_) @enum.method.type
-          (identifier) @enum.method.name
-          (formal_parameters) @enum.method.parameters
-        ) @enum.method.declaration
-
-        (method_declaration
-          (modifiers)? @enum.method.ignored.modifiers
-            (#match? @enum.method.ignored.modifiers "private|protected")
-        )
-
-        (field_declaration
-          (modifiers)? @enum.field.modifiers
-            (#not-match? @enum.field.modifiers "private|protected")
-          (variable_declarator
-            (identifier) @enum.field.name
-          )
-        ) @enum.field.declaration
-
-        (field_declaration
-          (modifiers)? @enum.field.ignored.modifiers
-            (#match? @enum.field.ignored.modifiers "private|protected")
-        ) @enum.field.ignored.declaration
-
-        (_)
-      ]*
-    )?
-  ) @enum.body
-) @enum.declaration
-
-; extract method names as separate matches for symbol outline
-(class_declaration
-  body: (_
-    (method_declaration
-      (modifiers)? @method.modifiers
-        (#not-match? @method.modifiers "private|protected")
-      (identifier) @method.name
-    )
-  )
-)
-
-; extract enum method names as separate matches for symbol outline
-(enum_declaration
-  (enum_body
-    (enum_body_declarations
-      (method_declaration
-        (modifiers)? @method.modifiers
-          (#not-match? @method.modifiers "private|protected")
-        (identifier) @method.name
-      )
-    )
-  )
-)
+; XXX NOTE: OLD QUERIES BELOW and commented out. these older queries are good
+; for referencing how to do these queries, but are not to be uncommented EVER.
+; Instead, add new queries above this line.
+; 
+;    (interface_declaration
+;      (modifiers)? @interface.modifiers
+;        (#not-match? @interface.modifiers "private|protected")
+;      (identifier) @interface.name
+;      (type_parameters)? @interface.type_parameters
+;        body: (_
+;          [
+;            (method_declaration) @interface.method.declaration
+;            (constant_declaration) @interface.constant.declaration
+;            (field_declaration) @interface.field.declaration
+;            (_)
+;          ]*
+;        ) @interface.body
+;    ) @interface.declaration
+;    
+;    (annotation_type_declaration
+;      (modifiers)? @annotation.modifiers
+;        (#not-match? @annotation.modifiers "private|protected")
+;      (identifier) @annotation.name
+;        body: (_
+;          [
+;            (annotation_type_element_declaration
+;              (modifiers)? @annotation.element.modifiers
+;                (#not-match? @annotation.element.modifiers "private|protected")
+;              type: (_) @annotation.element.type
+;              (identifier) @annotation.element.name
+;            ) @annotation.element.declaration
+;    
+;            (annotation_type_element_declaration
+;              (modifiers)? @annotation.element.ignore.modifiers
+;                (#match? @annotation.element.ignore.modifiers "private|protected")
+;            )
+;    
+;            (constant_declaration) @annotation.constant.declaration
+;    
+;            (_)
+;          ]*
+;        ) @annotation.body
+;    ) @annotation.declaration
+;    
+;    (class_declaration
+;      (modifiers)? @class.modifiers
+;        (#not-match? @class.modifiers "private|protected")
+;      (identifier) @class.name
+;      (type_parameters)? @class.type_parameters
+;        body: (_
+;          [
+;            (method_declaration
+;              (modifiers)? @class.method.modifiers
+;                (#not-match? @class.method.modifiers "private|protected")
+;              (type_parameters)? @class.method.type_parameters
+;              type: (_) @class.method.type
+;              (identifier) @class.method.name
+;              (formal_parameters) @class.method.parameters
+;            ) @class.method.declaration
+;    
+;            (method_declaration
+;              (modifiers)? @class.method.ignored.modifiers
+;                (#match? @class.method.ignored.modifiers "private|protected")
+;            )
+;    
+;            (constructor_declaration
+;              (modifiers)? @class.constructor.modifiers
+;                (#not-match? @class.constructor.modifiers "private|protected")
+;              (identifier) @class.constructor.name
+;              (formal_parameters) @class.constructor.parameters
+;            ) @class.constructor.declaration
+;    
+;            (constructor_declaration
+;              (modifiers)? @class.constructor.ignored.modifiers
+;                (#match? @class.constructor.ignored.modifiers "private|protected")
+;            )
+;    
+;            (field_declaration
+;              (modifiers)? @class.field.modifiers
+;                (#not-match? @class.field.modifiers "private|protected")
+;              (variable_declarator
+;                (identifier) @class.field.name
+;              )
+;            ) @class.field.declaration
+;    
+;            (field_declaration
+;              (modifiers)? @class.field.ignored.modifiers
+;                (#match? @class.field.ignored.modifiers "private|protected")
+;            ) @class.field.ignored.declaration
+;    
+;            (constant_declaration
+;              (modifiers)? @class.constant.modifiers
+;                (#not-match? @class.constant.modifiers "private|protected")
+;              (variable_declarator
+;                (identifier) @class.constant.name
+;              )
+;            ) @class.constant.declaration
+;    
+;            (constant_declaration
+;              (modifiers)? @class.constant.ignored.modifiers
+;                (#match? @class.constant.ignored.modifiers "private|protected")
+;            ) @class.constant.ignored.declaration
+;    
+;            (_)
+;          ]*
+;        ) @class.body
+;    ) @class.declaration
+;    
+;    (enum_declaration
+;      (modifiers)? @enum.modifiers
+;        (#not-match? @enum.modifiers "private|protected")
+;      (identifier) @enum.name
+;      body: (_
+;        ; bug in tree-sitter means * isn't working here, so hard-coding many with ? instead
+;        (enum_constant)? @enum.constant.declaration
+;        (enum_constant)? @enum.constant.declaration
+;        (enum_constant)? @enum.constant.declaration
+;        (enum_constant)? @enum.constant.declaration
+;        (enum_constant)? @enum.constant.declaration
+;        (enum_constant)? @enum.constant.declaration
+;        (enum_constant)? @enum.constant.declaration
+;        (enum_constant)? @enum.constant.declaration
+;        (enum_constant)? @enum.constant.declaration
+;        (enum_constant)? @enum.constant.declaration
+;        (enum_constant)? @enum.constant.declaration
+;        (enum_constant)? @enum.constant.declaration
+;        (enum_constant)? @enum.constant.declaration
+;        (enum_constant)? @enum.constant.declaration
+;        (enum_constant)? @enum.constant.declaration
+;        (enum_constant)? @enum.constant.declaration
+;        (enum_body_declarations
+;          [
+;            (method_declaration
+;              (modifiers)? @enum.method.modifiers
+;                (#not-match? @enum.method.modifiers "private|protected")
+;              type: (_) @enum.method.type
+;              (identifier) @enum.method.name
+;              (formal_parameters) @enum.method.parameters
+;            ) @enum.method.declaration
+;    
+;            (method_declaration
+;              (modifiers)? @enum.method.ignored.modifiers
+;                (#match? @enum.method.ignored.modifiers "private|protected")
+;            )
+;    
+;            (field_declaration
+;              (modifiers)? @enum.field.modifiers
+;                (#not-match? @enum.field.modifiers "private|protected")
+;              (variable_declarator
+;                (identifier) @enum.field.name
+;              )
+;            ) @enum.field.declaration
+;    
+;            (field_declaration
+;              (modifiers)? @enum.field.ignored.modifiers
+;                (#match? @enum.field.ignored.modifiers "private|protected")
+;            ) @enum.field.ignored.declaration
+;    
+;            (_)
+;          ]*
+;        )?
+;      ) @enum.body
+;    ) @enum.declaration
+;    
+;    ; extract method names as separate matches for symbol outline
+;    (class_declaration
+;      body: (_
+;        (method_declaration
+;          (modifiers)? @method.modifiers
+;            (#not-match? @method.modifiers "private|protected")
+;          (identifier) @method.name
+;        )
+;      )
+;    )
+;    
+;    ; extract enum method names as separate matches for symbol outline
+;    (enum_declaration
+;      (enum_body
+;        (enum_body_declarations
+;          (method_declaration
+;            (modifiers)? @method.modifiers
+;              (#not-match? @method.modifiers "private|protected")
+;            (identifier) @method.name
+;          )
+;        )
+;      )
+;    )

--- a/coding/tree_sitter/signature_queries/signature_java.scm
+++ b/coding/tree_sitter/signature_queries/signature_java.scm
@@ -1,3 +1,36 @@
+; Queries for top-level declarations (non-private/protected)
+
+(class_declaration
+  (modifiers)? @class.modifiers
+    (#not-match? @class.modifiers "private|protected")
+  name: (identifier) @class.name
+  (type_parameters)? @class.type_parameters
+  ; body: (_) @class.body ; Body not needed for signature capture itself
+) @class.declaration
+
+(interface_declaration
+  (modifiers)? @interface.modifiers
+    (#not-match? @interface.modifiers "private|protected")
+  name: (identifier) @interface.name
+  (type_parameters)? @interface.type_parameters
+  ; body: (_) @interface.body
+) @interface.declaration
+
+(enum_declaration
+  (modifiers)? @enum.modifiers
+    (#not-match? @enum.modifiers "private|protected")
+  name: (identifier) @enum.name
+  ; body: (_) @enum.body
+) @enum.declaration
+
+(annotation_type_declaration
+  (modifiers)? @annotation.modifiers
+    (#not-match? @annotation.modifiers "private|protected")
+  name: (identifier) @annotation.name
+  ; body: (_) @annotation.body
+) @annotation.declaration
+
+
 ; XXX NOTE: OLD QUERIES BELOW and commented out. these older queries are good
 ; for referencing how to do these queries, but are not to be uncommented EVER.
 ; Instead, add new queries above this line.

--- a/coding/tree_sitter/signature_queries/signature_java.scm
+++ b/coding/tree_sitter/signature_queries/signature_java.scm
@@ -1,220 +1,186 @@
-; Queries for top-level declarations (non-private/protected)
+;;----------------------------------------------------------------------------
+;; Unified Top-Level Queries for Declarations and Members
+;;----------------------------------------------------------------------------
+;; These queries capture non-private/protected top-level declarations
+;; (classes, interfaces, enums, annotations) and their non-private/protected
+;; members (methods, fields, constructors, enum constants, annotation elements).
+;; Member queries include predicates to check both member and container visibility.
+;; Capture names are designed for compatibility with writeJavaSignatureCapture (hierarchical)
+;; and symbol extraction (simple @*.name captures).
+;;----------------------------------------------------------------------------
 
+;; Class Declaration (captures the class itself)
 (class_declaration
   (modifiers)? @class.modifiers
-    (#not-match? @class.modifiers "private|protected")
+    (#not-match? @class.modifiers "(private|protected)")
   name: (identifier) @class.name
   (type_parameters)? @class.type_parameters
-  ; body: (_) @class.body ; Body not needed for signature capture itself
 ) @class.declaration
 
+;; Interface Declaration (captures the interface itself)
 (interface_declaration
   (modifiers)? @interface.modifiers
-    (#not-match? @interface.modifiers "private|protected")
+    (#not-match? @interface.modifiers "(private|protected)")
   name: (identifier) @interface.name
   (type_parameters)? @interface.type_parameters
-  ; body: (_) @interface.body
 ) @interface.declaration
 
+;; Enum Declaration (captures the enum itself)
 (enum_declaration
   (modifiers)? @enum.modifiers
-    (#not-match? @enum.modifiers "private|protected")
+    (#not-match? @enum.modifiers "(private|protected)")
   name: (identifier) @enum.name
-  ; body: (_) @enum.body
 ) @enum.declaration
 
+;; Annotation Type Declaration (captures the annotation type itself)
 (annotation_type_declaration
   (modifiers)? @annotation.modifiers
-    (#not-match? @annotation.modifiers "private|protected")
+    (#not-match? @annotation.modifiers "(private|protected)")
   name: (identifier) @annotation.name
-  ; body: (_) @annotation.body
 ) @annotation.declaration
 
+;; Methods in Classes
+(class_declaration
+  (modifiers)? @method.class.modifiers ; For parent visibility predicate check
+  (class_body
+    (method_declaration
+      (modifiers)? @method.modifiers ; Modifiers for signature
+        (#not-match? @method.modifiers "(private|protected)") ; Check method visibility
+      (type_parameters)? @method.type_parameters
+      type: (_) @method.type ; Return type
+      name: (identifier) @method.name ; Hierarchical and simple name
+      parameters: (_) @method.parameters ; Parameters
+    ) @method.declaration ; Capture the whole method for signature context
+  )
+  (#not-match? @method.class.modifiers "(private|protected)") ; Check class visibility
+)
 
-; XXX NOTE: OLD QUERIES BELOW and commented out. these older queries are good
-; for referencing how to do these queries, but are not to be uncommented EVER.
-; Instead, add new queries above this line.
-; 
-;    (interface_declaration
-;      (modifiers)? @interface.modifiers
-;        (#not-match? @interface.modifiers "private|protected")
-;      (identifier) @interface.name
-;      (type_parameters)? @interface.type_parameters
-;        body: (_
-;          [
-;            (method_declaration) @interface.method.declaration
-;            (constant_declaration) @interface.constant.declaration
-;            (field_declaration) @interface.field.declaration
-;            (_)
-;          ]*
-;        ) @interface.body
-;    ) @interface.declaration
-;    
-;    (annotation_type_declaration
-;      (modifiers)? @annotation.modifiers
-;        (#not-match? @annotation.modifiers "private|protected")
-;      (identifier) @annotation.name
-;        body: (_
-;          [
-;            (annotation_type_element_declaration
-;              (modifiers)? @annotation.element.modifiers
-;                (#not-match? @annotation.element.modifiers "private|protected")
-;              type: (_) @annotation.element.type
-;              (identifier) @annotation.element.name
-;            ) @annotation.element.declaration
-;    
-;            (annotation_type_element_declaration
-;              (modifiers)? @annotation.element.ignore.modifiers
-;                (#match? @annotation.element.ignore.modifiers "private|protected")
-;            )
-;    
-;            (constant_declaration) @annotation.constant.declaration
-;    
-;            (_)
-;          ]*
-;        ) @annotation.body
-;    ) @annotation.declaration
-;    
-;    (class_declaration
-;      (modifiers)? @class.modifiers
-;        (#not-match? @class.modifiers "private|protected")
-;      (identifier) @class.name
-;      (type_parameters)? @class.type_parameters
-;        body: (_
-;          [
-;            (method_declaration
-;              (modifiers)? @class.method.modifiers
-;                (#not-match? @class.method.modifiers "private|protected")
-;              (type_parameters)? @class.method.type_parameters
-;              type: (_) @class.method.type
-;              (identifier) @class.method.name
-;              (formal_parameters) @class.method.parameters
-;            ) @class.method.declaration
-;    
-;            (method_declaration
-;              (modifiers)? @class.method.ignored.modifiers
-;                (#match? @class.method.ignored.modifiers "private|protected")
-;            )
-;    
-;            (constructor_declaration
-;              (modifiers)? @class.constructor.modifiers
-;                (#not-match? @class.constructor.modifiers "private|protected")
-;              (identifier) @class.constructor.name
-;              (formal_parameters) @class.constructor.parameters
-;            ) @class.constructor.declaration
-;    
-;            (constructor_declaration
-;              (modifiers)? @class.constructor.ignored.modifiers
-;                (#match? @class.constructor.ignored.modifiers "private|protected")
-;            )
-;    
-;            (field_declaration
-;              (modifiers)? @class.field.modifiers
-;                (#not-match? @class.field.modifiers "private|protected")
-;              (variable_declarator
-;                (identifier) @class.field.name
-;              )
-;            ) @class.field.declaration
-;    
-;            (field_declaration
-;              (modifiers)? @class.field.ignored.modifiers
-;                (#match? @class.field.ignored.modifiers "private|protected")
-;            ) @class.field.ignored.declaration
-;    
-;            (constant_declaration
-;              (modifiers)? @class.constant.modifiers
-;                (#not-match? @class.constant.modifiers "private|protected")
-;              (variable_declarator
-;                (identifier) @class.constant.name
-;              )
-;            ) @class.constant.declaration
-;    
-;            (constant_declaration
-;              (modifiers)? @class.constant.ignored.modifiers
-;                (#match? @class.constant.ignored.modifiers "private|protected")
-;            ) @class.constant.ignored.declaration
-;    
-;            (_)
-;          ]*
-;        ) @class.body
-;    ) @class.declaration
-;    
-;    (enum_declaration
-;      (modifiers)? @enum.modifiers
-;        (#not-match? @enum.modifiers "private|protected")
-;      (identifier) @enum.name
-;      body: (_
-;        ; bug in tree-sitter means * isn't working here, so hard-coding many with ? instead
-;        (enum_constant)? @enum.constant.declaration
-;        (enum_constant)? @enum.constant.declaration
-;        (enum_constant)? @enum.constant.declaration
-;        (enum_constant)? @enum.constant.declaration
-;        (enum_constant)? @enum.constant.declaration
-;        (enum_constant)? @enum.constant.declaration
-;        (enum_constant)? @enum.constant.declaration
-;        (enum_constant)? @enum.constant.declaration
-;        (enum_constant)? @enum.constant.declaration
-;        (enum_constant)? @enum.constant.declaration
-;        (enum_constant)? @enum.constant.declaration
-;        (enum_constant)? @enum.constant.declaration
-;        (enum_constant)? @enum.constant.declaration
-;        (enum_constant)? @enum.constant.declaration
-;        (enum_constant)? @enum.constant.declaration
-;        (enum_constant)? @enum.constant.declaration
-;        (enum_body_declarations
-;          [
-;            (method_declaration
-;              (modifiers)? @enum.method.modifiers
-;                (#not-match? @enum.method.modifiers "private|protected")
-;              type: (_) @enum.method.type
-;              (identifier) @enum.method.name
-;              (formal_parameters) @enum.method.parameters
-;            ) @enum.method.declaration
-;    
-;            (method_declaration
-;              (modifiers)? @enum.method.ignored.modifiers
-;                (#match? @enum.method.ignored.modifiers "private|protected")
-;            )
-;    
-;            (field_declaration
-;              (modifiers)? @enum.field.modifiers
-;                (#not-match? @enum.field.modifiers "private|protected")
-;              (variable_declarator
-;                (identifier) @enum.field.name
-;              )
-;            ) @enum.field.declaration
-;    
-;            (field_declaration
-;              (modifiers)? @enum.field.ignored.modifiers
-;                (#match? @enum.field.ignored.modifiers "private|protected")
-;            ) @enum.field.ignored.declaration
-;    
-;            (_)
-;          ]*
-;        )?
-;      ) @enum.body
-;    ) @enum.declaration
-;    
-;    ; extract method names as separate matches for symbol outline
-;    (class_declaration
-;      body: (_
-;        (method_declaration
-;          (modifiers)? @method.modifiers
-;            (#not-match? @method.modifiers "private|protected")
-;          (identifier) @method.name
-;        )
-;      )
-;    )
-;    
-;    ; extract enum method names as separate matches for symbol outline
-;    (enum_declaration
-;      (enum_body
-;        (enum_body_declarations
-;          (method_declaration
-;            (modifiers)? @method.modifiers
-;              (#not-match? @method.modifiers "private|protected")
-;            (identifier) @method.name
-;          )
-;        )
-;      )
-;    )
+;; Methods in Interfaces (default or static - abstract methods are part of interface decl)
+(interface_declaration
+  (modifiers)? @method.interface.modifiers ; For parent visibility predicate check
+  (interface_body
+    (method_declaration
+      (modifiers)? @method.modifiers
+        ; Interface methods are implicitly public unless private (Java 9+) or static/default
+        (#not-match? @method.modifiers "(private)") ; Allow public (implicit), static, default
+      (type_parameters)? @method.type_parameters
+      type: (_) @method.type
+      name: (identifier) @method.name
+      parameters: (_) @method.parameters
+    ) @method.declaration
+  )
+  (#not-match? @method.interface.modifiers "(private|protected)") ; Check interface visibility
+)
+
+;; Methods in Enums
+(enum_declaration
+  (modifiers)? @method.enum.modifiers ; For parent visibility predicate check
+  (enum_body
+    (enum_body_declarations
+      (method_declaration
+        (modifiers)? @method.modifiers
+        (type_parameters)? @method.type_parameters
+        type: (_) @method.type
+        name: (identifier) @method.name
+        parameters: (_) @method.parameters
+        (#not-match? @method.modifiers "(private|protected)") ; Check method visibility
+      ) @method.declaration
+    )
+  )
+  (#not-match? @method.enum.modifiers "(private|protected)") ; Check enum visibility
+)
+
+;; Constructors in Classes
+(class_declaration
+  (modifiers)? @constructor.class.modifiers ; For parent visibility predicate check
+  (class_body
+    (constructor_declaration
+      (modifiers)? @constructor.modifiers ; Modifiers for signature
+      name: (identifier) @constructor.name
+      parameters: (_) @constructor.parameters ; Parameters
+      (#not-match? @constructor.modifiers "(private|protected)") ; Check: constructor visibility
+    ) @constructor.declaration ; Capture the whole constructor
+  )
+  (#not-match? @constructor.class.modifiers "(private|protected)") ; Check class visibility
+)
+
+;; fields/constants in Classes (captures each declarator)
+(class_declaration
+  (modifiers)? @field.class.modifiers ; For parent visibility predicate check
+  (class_body
+    (field_declaration
+      (modifiers)? @field.modifiers ; Modifiers for the whole declaration
+      type: (_) @field.type ; Type for the whole declaration
+      (variable_declarator
+        name: (identifier) @field.name
+        value: (_)? @field.value ; Optional value
+        dimensions: (_)? @field.dimensions ; Optional array dimensions on declarator
+      ) @declarator ; Capture each declarator
+      (#not-match? @field.modifiers "(private|protected)") ; Check field visibility based on declaration modifiers
+    ) @field.declaration ; Capture the whole field declaration (match per declarator)
+  )
+  (#not-match? @field.class.modifiers "(private|protected)") ; Check class visibility
+)
+
+;; Constants in Interfaces (captures each declarator)
+(interface_declaration
+  (modifiers)? @constant.interface.modifiers ; For parent visibility predicate check
+  (interface_body
+    (constant_declaration ; Constants in interfaces are implicitly public static final
+      (modifiers)? @constant.modifiers ; Modifiers for the whole declaration
+      type: (_) @constant.type
+      (variable_declarator
+        name: (identifier) @constant.name
+        value: (_) @constant.value
+        dimensions: (_)? @constant.dimensions
+      ) @declarator
+      ; No visibility check needed, implicitly public
+    ) @constant.declaration
+  )
+  (#not-match? @constant.interface.modifiers "(private|protected)") ; Check interface visibility
+)
+
+;; Enum Constants
+(enum_declaration
+  (modifiers)? @constant.enum.modifiers ; For parent visibility predicate check
+  (enum_body
+    (enum_constant
+      (modifiers)? @constant.modifiers ; Modifiers for the whole declaration
+      name: (identifier) @constant.name ; Hierarchical and simple name
+      arguments: (_)? @constant.arguments ; Optional arguments
+    ) @constant.declaration ; Capture the constant
+    ; No explicit visibility check needed for enum constants, they are implicitly public static final
+  )
+  (#not-match? @constant.enum.modifiers "(private|protected)") ; Check enum visibility
+)
+
+;; Annotation Type Constants
+(annotation_type_declaration
+  (modifiers)? @constant.annotation.modifiers ; For parent visibility predicate check
+  (annotation_type_body
+    (constant_declaration
+      (modifiers)? @constant.modifiers ; Modifiers for the whole declaration
+      type: (_) @constant.type
+      (variable_declarator
+        name: (identifier) @constant.name
+        value: (_) @constant.value
+        dimensions: (_)? @constant.dimensions
+      ) @declarator
+    ) @constant.declaration
+  )
+  (#not-match? @constant.annotation.modifiers "(private|protected)") ; Check annotation visibility
+)
+
+;; Annotation Type Elements
+(annotation_type_declaration
+  (modifiers)? @annotation_type_element.annotation.modifiers ; For parent visibility predicate check
+  (annotation_type_body
+    (annotation_type_element_declaration
+      (modifiers)? @annotation_type_element.modifiers ; Modifiers (usually public abstract)
+      type: (_) @annotation_type_element.type ; Type
+      name: (identifier) @annotation_type_element.name
+      ; No explicit visibility check needed, implicitly public abstract
+    ) @annotation_type_element.declaration ; Capture the element
+  )
+  (#not-match? @annotation_type_element.annotation.modifiers "(private|protected)") ; Check annotation visibility
+)

--- a/coding/tree_sitter/symbol_definition_queries/symbol_definition_java.scm.mustache
+++ b/coding/tree_sitter/symbol_definition_queries/symbol_definition_java.scm.mustache
@@ -50,19 +50,6 @@
   (#eq? @name "{{SymbolName}}")
 ) @definition
 
-; Constructor declarations
-(
-  [
-    (block_comment)
-    (line_comment)
-  ]* @doc
-  .
-  (constructor_declaration
-    name: (identifier) @name
-  )
-  (#eq? @name "{{SymbolName}}")
-) @definition
-
 ; Field declarations
 (
   [


### PR DESCRIPTION
This happened with kotlin previously too, so we copied the fix: removing nested queries, instead simplifying each match to its own context.